### PR TITLE
Extracting error messages from trailer headers upon parsing exceptions

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -37,10 +37,6 @@ import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.joda.time.DateTime;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
-import java.lang.reflect.Method;
-import java.net.URLDecoder;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -125,7 +121,12 @@ public class NeptuneSparqlClient implements AutoCloseable {
             connection.prepareTupleQuery(sparql).evaluate(new TupleQueryHandler(writer, factory));
 
         } catch (Exception e) {
-            throw new RuntimeException(getErrorMessageFromTrailers(repository), e);
+            if (repository instanceof NeptuneExportSparqlRepository) {
+                throw new RuntimeException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
+            }
+            else {
+                throw new RuntimeException(e);
+            }
         }
     }
 
@@ -140,53 +141,18 @@ public class NeptuneSparqlClient implements AutoCloseable {
             connection.prepareGraphQuery(sparql).evaluate(new GraphQueryHandler(writer));
 
         } catch (Exception e) {
-            throw new RuntimeException(getErrorMessageFromTrailers(repository), e);
+            if (repository instanceof NeptuneExportSparqlRepository) {
+                throw new RuntimeException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
+            }
+            else {
+                throw new RuntimeException(e);
+            }
         }
     }
 
 
     private SPARQLRepository chooseRepository() {
         return repositories.get(random.nextInt(repositories.size()));
-    }
-
-    /**
-     * Attempts to extract error messages from trailing headers from the most recent response received by 'repository'.
-     * If no trailers are found an empty String is returned.
-     */
-    private String getErrorMessageFromTrailers(SPARQLRepository repository) {
-        if(repository instanceof NeptuneExportSparqlRepository) {
-            InputStream responseInStream = (InputStream) ((NeptuneExportSparqlRepository) repository).lastContext.getAttribute("raw-response-inputstream");
-            ChunkedInputStream chunkedInStream;
-            if (responseInStream instanceof ChunkedInputStream) {
-                chunkedInStream = (ChunkedInputStream) responseInStream;
-            }
-            else if (responseInStream instanceof EofSensorInputStream) {
-                // HTTPClient 4.5.13 provides no methods for accessing trailers from a wrapped stream requiring the use
-                // reflection to break encapsulation. This bug is being tracked in https://issues.apache.org/jira/browse/HTTPCLIENT-2263.
-                try {
-                    Method getWrappedStream = EofSensorInputStream.class.getDeclaredMethod("getWrappedStream");
-                    getWrappedStream.setAccessible(true);
-                    chunkedInStream = (ChunkedInputStream) getWrappedStream.invoke(responseInStream);
-                    getWrappedStream.setAccessible(false);
-                } catch (Exception e) {
-                    return "";
-                }
-            }
-            else {
-                return "";
-            }
-            Header[] trailers = chunkedInStream.getFooters();
-            String message = "";
-            for (Header trailer : trailers) {
-                try {
-                    message += URLDecoder.decode(trailer.toString(), "UTF-8") + "\n";
-                } catch (UnsupportedEncodingException e) {
-                    message += trailer + "\n";
-                }
-            }
-            return message;
-        }
-        return "";
     }
 
     @Override

--- a/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
@@ -28,7 +28,6 @@ import org.apache.http.conn.EofSensorInputStream;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.impl.io.ChunkedInputStream;
 import org.apache.http.protocol.HttpContext;
-import org.eclipse.rdf4j.http.client.SharedHttpClientSessionManager;
 import org.eclipse.rdf4j.http.client.util.HttpClientBuilders;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 
@@ -128,15 +127,16 @@ public class NeptuneExportSparqlRepository extends SPARQLRepository {
             return "";
         }
         Header[] trailers = chunkedInStream.getFooters();
-        String message = "";
+        StringBuilder messageBuilder = new StringBuilder();
         for (Header trailer : trailers) {
             try {
-                message += URLDecoder.decode(trailer.toString(), "UTF-8") + "\n";
+                messageBuilder.append(URLDecoder.decode(trailer.toString(), "UTF-8"));
             } catch (UnsupportedEncodingException e) {
-                message += trailer + "\n";
+                messageBuilder.append(trailer);
             }
+            messageBuilder.append('\n');
         }
-        return message;
+        return messageBuilder.toString();
     }
 
 }

--- a/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
@@ -113,7 +113,7 @@ public class NeptuneExportSparqlRepository extends SPARQLRepository {
             chunkedInStream = (ChunkedInputStream) responseInStream;
         }
         else if (responseInStream instanceof EofSensorInputStream) {
-            // HTTPClient 4.5.13 provides no methods for accessing trailers from a wrapped stream requiring the use
+            // HTTPClient 4.5.13 provides no methods for accessing trailers from a wrapped stream requiring the use of
             // reflection to break encapsulation. This bug is being tracked in https://issues.apache.org/jira/browse/HTTPCLIENT-2263.
             try {
                 Method getWrappedStream = EofSensorInputStream.class.getDeclaredMethod("getWrappedStream");


### PR DESCRIPTION
Issue #, if available: #17 and #127 (amazon-neptune-tools repo)

Description of changes:

Neptune sends it's responses using chunked-encoding. Because of this, it is possible that a query may fail after some data has already been sent back. In this case, Neptune will append the failure message at the end of the message body, often resulting in a corrupted message. Neptune can also include the error message and status code in a trailer header. This PR introduces changes which will attempt to extract these trailer headers when an RDF export fails and add the messages to the exception message.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

