### PR TITLE
Fix String formatting typo/bug in FileToStreamOutputWriter.java

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/io/FileToStreamOutputWriter.java
+++ b/src/main/java/com/amazonaws/services/neptune/io/FileToStreamOutputWriter.java
@@ -43,7 +43,7 @@ public class FileToStreamOutputWriter implements OutputWriter {
 
     @Override
     public String outputId() {
-        return String.format("%s [for stream %]", filePath.toString(), stream.name());
+        return String.format("%s [for stream %s]", filePath.toString(), stream.name());
     }
 
     @Override


### PR DESCRIPTION
Issue #, if available: n/a

Description of changes: A typo in file FileToStreamOutputWriter.java causes the outputId() method to fail. This commit just fixes that typo.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

