### PR TITLE
Fixes NPE's in NeptuneExportSparqlRepository and adds unit tests

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepository.java
@@ -46,12 +46,11 @@ public class NeptuneExportSparqlRepository extends SPARQLRepository {
 
     private HttpContext lastContext;
 
-    public NeptuneExportSparqlRepository(String endpointUrl) throws NeptuneSigV4SignerException {
-        this(endpointUrl, null, null, null);
-    }
-
     public NeptuneExportSparqlRepository(String endpointUrl, AWSCredentialsProvider awsCredentialsProvider, String regionName, ConnectionConfig config) throws NeptuneSigV4SignerException {
         super(getSparqlEndpoint(endpointUrl));
+        if (config == null) {
+            throw new IllegalArgumentException("ConnectionConfig is required to be non-null");
+        }
         this.config = config;
         this.awsCredentialsProvider = awsCredentialsProvider;
         this.regionName = regionName;
@@ -106,6 +105,9 @@ public class NeptuneExportSparqlRepository extends SPARQLRepository {
      * If no trailers are found an empty String is returned.
      */
     public String getErrorMessageFromTrailers() {
+        if (this.lastContext == null) {
+            return "";
+        }
         InputStream responseInStream = (InputStream) this.lastContext.getAttribute("raw-response-inputstream");
         ChunkedInputStream chunkedInStream;
         if (responseInStream instanceof ChunkedInputStream) {
@@ -137,6 +139,10 @@ public class NeptuneExportSparqlRepository extends SPARQLRepository {
             messageBuilder.append('\n');
         }
         return messageBuilder.toString();
+    }
+
+    protected void setLastContext(HttpContext context) {
+        this.lastContext = context;
     }
 
 }

--- a/src/test/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepositoryTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/io/NeptuneExportSparqlRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.amazonaws.services.neptune.rdf.io;
+
+import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
+import com.amazonaws.services.neptune.cluster.ConnectionConfig;
+import org.apache.http.Header;
+import org.apache.http.conn.EofSensorInputStream;
+import org.apache.http.impl.io.ChunkedInputStream;
+import org.apache.http.message.BasicHeader;
+import org.apache.http.protocol.HttpContext;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NeptuneExportSparqlRepositoryTest {
+
+    @Test
+    public void ShouldGetEmptyErrorMessageFromNewRepository() throws NeptuneSigV4SignerException {
+        ConnectionConfig mockedConfig = mock(ConnectionConfig.class);
+        NeptuneExportSparqlRepository repo = new NeptuneExportSparqlRepository("test", null, null, mockedConfig);
+        assertEquals("", repo.getErrorMessageFromTrailers());
+    }
+
+    @Test
+    public void ShouldGetTrailerErrorMessagesFromChunkedStream() throws NeptuneSigV4SignerException {
+        ConnectionConfig mockedConfig = mock(ConnectionConfig.class);
+        NeptuneExportSparqlRepository repo = new NeptuneExportSparqlRepository("test", null, null, mockedConfig);
+
+        ChunkedInputStream mockedStream = mock(ChunkedInputStream.class);
+        when(mockedStream.getFooters()).thenReturn(new Header[]{new BasicHeader("name", "value")});
+
+        HttpContext mockedContext = mock(HttpContext.class);
+        when(mockedContext.getAttribute("raw-response-inputstream")).thenReturn(mockedStream);
+
+        repo.setLastContext(mockedContext);
+
+        assertEquals("name: value\n", repo.getErrorMessageFromTrailers());
+    }
+
+    @Test
+    public void ShouldGetTrailerErrorMessagesFromEofSensorInputStream() throws NeptuneSigV4SignerException {
+        ConnectionConfig mockedConfig = mock(ConnectionConfig.class);
+        NeptuneExportSparqlRepository repo = new NeptuneExportSparqlRepository("test", null, null, mockedConfig);
+
+        ChunkedInputStream mockedStream = mock(ChunkedInputStream.class);
+        when(mockedStream.getFooters()).thenReturn(new Header[]{new BasicHeader("name", "value")});
+
+        EofSensorInputStream eofSensorInputStream = new EofSensorInputStream(mockedStream, null);
+
+        HttpContext mockedContext = mock(HttpContext.class);
+        when(mockedContext.getAttribute("raw-response-inputstream")).thenReturn(eofSensorInputStream);
+
+        repo.setLastContext(mockedContext);
+
+        assertEquals("name: value\n", repo.getErrorMessageFromTrailers());
+    }
+}


### PR DESCRIPTION
Issue #, if available: #27

Description of changes:

Fixes NPE from attempting to get error message from trailers before any context has been stored. Also adds a requirement that a non-null ConnectionConfig is passed when constructing a NeptuneExportSparqlRepository as the class currently operates under the assumption that it will never be null.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

