### PR TITLE
Upgrade to TinkerPop 3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -20,12 +20,12 @@
         <javac.target>1.8</javac.target>
         <uberjar.name>neptune-export-${project.version}-all</uberjar.name>
         <aws.sdk.version>1.12.359</aws.sdk.version>
-        <gremlin.version>3.4.8</gremlin.version>
+        <gremlin.version>3.6.2</gremlin.version>
         <slf4j.version>2.0.5</slf4j.version>
         <rdf4j.version>3.5.0</rdf4j.version>
-        <amazon.neptune.sigv4.signer.version>2.1.1</amazon.neptune.sigv4.signer.version>
-        <amazon.neptune.gremlin.java.sigv4.version>2.1.1</amazon.neptune.gremlin.java.sigv4.version>
-        <amazon.neptune.sparql.java.sigv4.version>2.1.1</amazon.neptune.sparql.java.sigv4.version>
+        <amazon.neptune.sigv4.signer.version>2.4.0</amazon.neptune.sigv4.signer.version>
+        <amazon.neptune.gremlin.java.sigv4.version>2.4.0</amazon.neptune.gremlin.java.sigv4.version>
+        <amazon.neptune.sparql.java.sigv4.version>2.4.0</amazon.neptune.sparql.java.sigv4.version>
         <netty.version>4.1.52.Final</netty.version>
         <kinesis.producer.version>0.14.0</kinesis.producer.version>
     </properties>
@@ -36,6 +36,12 @@
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-driver</artifactId>
             <version>0.5.3</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-core</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-core</artifactId>
+            <artifactId>mockito-inline</artifactId>
             <version>2.25.0</version>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinQueryDebugger.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinQueryDebugger.java
@@ -12,11 +12,11 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.propertygraph;
 
-import org.apache.tinkerpop.gremlin.groovy.jsr223.GroovyTranslator;
+import org.apache.tinkerpop.gremlin.process.traversal.translator.GroovyTranslator;
 
 public class GremlinQueryDebugger {
 
     public static String queryAsString(Object o){
-        return String.valueOf(new GroovyTranslator.DefaultTypeTranslator().apply("g", o));
+        return new GroovyTranslator.DefaultTypeTranslator(false).apply("g", o).getScript();
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
 import com.amazonaws.services.neptune.cluster.ConnectionConfig;
 import com.amazonaws.services.neptune.propertygraph.io.SerializationConfig;
 import org.apache.tinkerpop.gremlin.driver.*;
+import org.apache.tinkerpop.gremlin.driver.Cluster.Builder;
 import org.apache.tinkerpop.gremlin.driver.remote.DriverRemoteConnection;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -41,7 +42,7 @@ public class NeptuneGremlinClient implements AutoCloseable {
             logger.warn("SSL has been disabled");
         }
 
-        org.apache.tinkerpop.gremlin.driver.Cluster.Builder builder = org.apache.tinkerpop.gremlin.driver.Cluster.build()
+        Builder builder = org.apache.tinkerpop.gremlin.driver.Cluster.build()
                 .port(connectionConfig.port())
                 .enableSsl(connectionConfig.useSsl())
                 .maxWaitForConnection(10000);
@@ -49,27 +50,7 @@ public class NeptuneGremlinClient implements AutoCloseable {
         builder = serializationConfig.apply(builder);
 
         if (connectionConfig.useIamAuth()) {
-            if (connectionConfig.isDirectConnection()) {
-                builder = builder.handshakeInterceptor( r ->
-                        {
-                            try {
-                                NeptuneNettyHttpSigV4Signer sigV4Signer =
-                                        new NeptuneNettyHttpSigV4Signer(
-                                                new ChainedSigV4PropertiesProvider().getSigV4Properties().getServiceRegion(),
-                                                new DefaultAWSCredentialsProviderChain());
-                                sigV4Signer.signRequest(r);
-                            } catch (NeptuneSigV4SignerException e) {
-                                throw new RuntimeException("Exception occurred while signing the request", e);
-                            }
-                            return r;
-                        }
-                );
-            } else {
-                builder = builder
-                        // use the JAAS_ENTRY auth property to pass Host header info to the channelizer
-                        .authProperties(new AuthProperties().with(AuthProperties.Property.JAAS_ENTRY, connectionConfig.handshakeRequestConfig().value()))
-                        .channelizer(LBAwareSigV4WebSocketChannelizer.class);
-            }
+            builder = configureIamSigning(builder, connectionConfig);
         }
 
         for (String endpoint : connectionConfig.endpoints()) {
@@ -79,6 +60,31 @@ public class NeptuneGremlinClient implements AutoCloseable {
         int numberOfEndpoints = connectionConfig.endpoints().size();
 
         return new NeptuneGremlinClient(concurrencyConfig.applyTo(builder, numberOfEndpoints).create());
+    }
+
+    protected static Builder configureIamSigning (Builder builder, ConnectionConfig connectionConfig) {
+        if (connectionConfig.isDirectConnection()) {
+            builder = builder.handshakeInterceptor( r ->
+                    {
+                        try {
+                            NeptuneNettyHttpSigV4Signer sigV4Signer =
+                                    new NeptuneNettyHttpSigV4Signer(
+                                            new ChainedSigV4PropertiesProvider().getSigV4Properties().getServiceRegion(),
+                                            new DefaultAWSCredentialsProviderChain());
+                            sigV4Signer.signRequest(r);
+                        } catch (NeptuneSigV4SignerException e) {
+                            throw new RuntimeException("Exception occurred while signing the request", e);
+                        }
+                        return r;
+                    }
+            );
+        } else {
+            builder = builder
+                    // use the JAAS_ENTRY auth property to pass Host header info to the channelizer
+                    .authProperties(new AuthProperties().with(AuthProperties.Property.JAAS_ENTRY, connectionConfig.handshakeRequestConfig().value()))
+                    .channelizer(LBAwareSigV4WebSocketChannelizer.class);
+        }
+        return builder;
     }
 
     private final org.apache.tinkerpop.gremlin.driver.Cluster cluster;

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
@@ -78,7 +78,7 @@ public class LBAwareSigV4WebSocketChannelizer extends Channelizer.AbstractChanne
      * Name of the WebSocket handler.
      */
 
-    private static final String WEB_SOCKET_HANDLER = "ws-handler";
+    protected static final String WEB_SOCKET_HANDLER = "ws-handler";
     /**
      * Name of the GremlinEncoder handler.
      */

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
@@ -42,10 +42,8 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.http.EmptyHttpHeaders;
 import io.netty.handler.codec.http.HttpClientCodec;
-import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.websocketx.CloseWebSocketFrame;
-import io.netty.handler.codec.http.websocketx.PingWebSocketFrame;
 import io.netty.handler.codec.http.websocketx.WebSocketClientHandshaker;
 import io.netty.handler.codec.http.websocketx.WebSocketVersion;
 import org.apache.tinkerpop.gremlin.driver.exception.ConnectionException;
@@ -123,20 +121,6 @@ public class LBAwareSigV4WebSocketChannelizer extends Channelizer.AbstractChanne
     }
 
     /**
-     * Keep-alive is supported through the ping/pong websocket protocol.
-     * @see <a href=https://tools.ietf.org/html/rfc6455#section-5.5.2>IETF RFC 6455</a>
-     */
-    @Override
-    public boolean supportsKeepAlive() {
-        return true;
-    }
-
-    @Override
-    public Object createKeepAliveMessage() {
-        return new PingWebSocketFrame();
-    }
-
-    /**
      * Sends a {@code CloseWebSocketFrame} to the server for the specified channel.
      */
     @Override
@@ -206,6 +190,6 @@ public class LBAwareSigV4WebSocketChannelizer extends Channelizer.AbstractChanne
                 cluster.getMaxContentLength(),
                 new ChainedSigV4PropertiesProvider(),
                 handshakeRequestConfig);
-        return new WebSocketClientHandler(handshaker);
+        return new WebSocketClientHandler(handshaker, 10000, supportsSsl());
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/ExportPgIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportPgIntegrationTest.java
@@ -19,4 +19,14 @@ public class ExportPgIntegrationTest extends AbstractExportIntegrationTest{
         assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgToCsv"), resultDir);
     }
 
+    @Test
+    public void testExportPgToCsvWithJanus() {
+        final String[] command = {"export-pg", "-e", neptuneEndpoint, "-d", outputDir.getPath(), "--janus"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgToCsv"), resultDir);
+    }
 }

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClientTest.java
@@ -1,0 +1,123 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import com.amazonaws.services.neptune.auth.HandshakeRequestConfig;
+import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
+import com.amazonaws.services.neptune.cluster.ConnectionConfig;
+import com.amazonaws.services.neptune.propertygraph.io.SerializationConfig;
+import org.apache.tinkerpop.gremlin.driver.Cluster;
+import org.apache.tinkerpop.gremlin.driver.HandshakeInterceptor;
+import org.apache.tinkerpop.gremlin.driver.LBAwareSigV4WebSocketChannelizer;
+import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
+import org.junit.Test;
+import org.apache.tinkerpop.gremlin.driver.Client;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Collection;
+import java.util.HashSet;
+
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class NeptuneGremlinClientTest {
+
+    private final SerializationConfig defaultSerializationConfig = new SerializationConfig(
+            Serializers.GRAPHBINARY_V1D0.name(), 50000000, NeptuneGremlinClient.DEFAULT_BATCH_SIZE, false);
+
+    @Test
+    public void testQueryClientSubmit() {
+        Client mockedClient = mock(Client.class);
+        NeptuneGremlinClient.QueryClient qc = new NeptuneGremlinClient.QueryClient(mockedClient);
+        qc.submit("test", null);
+        verify(mockedClient).submit("test");
+    }
+
+    @Test
+    public void testConnectionConfigPassthrough() {
+        com.amazonaws.services.neptune.cluster.Cluster mockedCluster = mock(com.amazonaws.services.neptune.cluster.Cluster.class);
+        Collection endpoints = new HashSet();
+        endpoints.add("localhost");
+
+        //With SSL Enabled
+        when(mockedCluster.connectionConfig()).thenReturn(new ConnectionConfig(
+                null, endpoints, 1234, false, true, null));
+        when(mockedCluster.concurrencyConfig()).thenReturn(new ConcurrencyConfig(1));
+
+        NeptuneGremlinClient client = NeptuneGremlinClient.create(mockedCluster, defaultSerializationConfig);
+
+        Cluster cluster = getClusterFromClient(client);
+        cluster.init();
+
+        assertEquals(1234, cluster.getPort());
+        assertEquals("wss://localhost:1234/gremlin", cluster.allHosts().iterator().next().getHostUri().toString());
+        assertEquals(true, cluster.isSslEnabled());
+
+        //With SSL Disabled
+        when(mockedCluster.connectionConfig()).thenReturn(new ConnectionConfig(
+                null, endpoints, 1234, false, false, null));
+        client = NeptuneGremlinClient.create(mockedCluster, defaultSerializationConfig);
+
+        cluster = getClusterFromClient(client);
+        cluster.init();
+
+        assertEquals("ws://localhost:1234/gremlin", cluster.allHosts().iterator().next().getHostUri().toString());
+        assertEquals(false, cluster.isSslEnabled());
+
+    }
+
+    @Test
+    public void shouldUseHandshakeInterceptorForSigningDirectConnections() {
+        ConnectionConfig mockedConfig = mock(ConnectionConfig.class);
+        when(mockedConfig.isDirectConnection()).thenReturn(true);
+
+        Cluster.Builder builder = Cluster.build();
+
+        builder = NeptuneGremlinClient.configureIamSigning(builder, mockedConfig);
+
+        Cluster cluster = builder.create();
+
+        HandshakeInterceptor interceptor;
+
+        try {
+            Method getHandshakeInterceptor = cluster.getClass().getDeclaredMethod("getHandshakeInterceptor");
+            getHandshakeInterceptor.setAccessible(true);
+            interceptor = (HandshakeInterceptor) getHandshakeInterceptor.invoke(cluster);
+            getHandshakeInterceptor.setAccessible(false);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        assertNotNull(interceptor);
+        assertNotEquals(interceptor, HandshakeInterceptor.NO_OP);
+
+    }
+
+    @Test
+    public void shouldUseLBAwareChannelizerForSigningProxyConnections() {
+        ConnectionConfig mockedConfig = mock(ConnectionConfig.class);
+        when(mockedConfig.isDirectConnection()).thenReturn(false);
+        when(mockedConfig.handshakeRequestConfig()).thenReturn(mock(HandshakeRequestConfig.class));
+        Cluster.Builder builder = Cluster.build();
+
+        builder = NeptuneGremlinClient.configureIamSigning(builder, mockedConfig);
+
+        assertEquals(LBAwareSigV4WebSocketChannelizer.class.getName(), builder.create().getChannelizer());
+    }
+
+    private static Cluster getClusterFromClient(NeptuneGremlinClient client) {
+        try {
+            Field clusterField = client.getClass().getDeclaredField("cluster");
+            clusterField.setAccessible(true);
+            Cluster cluster = (Cluster) clusterField.get(client);
+            clusterField.setAccessible(false);
+            return cluster;
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizerTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizerTest.java
@@ -31,6 +31,8 @@ import static org.mockito.Mockito.when;
 public class LBAwareSigV4WebSocketChannelizerTest  {
     @Test
     public void configureShouldAddSigV4HandshakerToPipeline() throws URISyntaxException {
+        System.setProperty("SERVICE_REGION", "us-west-2");
+
         ChannelPipeline mockedPipeline = new EmbeddedChannel().pipeline();
         LBAwareSigV4WebSocketChannelizer channelizer = new LBAwareSigV4WebSocketChannelizer();
         Connection mockedConnection = mock(Connection.class);

--- a/src/test/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizerTest.java
+++ b/src/test/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizerTest.java
@@ -1,0 +1,52 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package org.apache.tinkerpop.gremlin.driver;
+
+import com.amazonaws.services.neptune.auth.HandshakeRequestConfig;
+import com.amazonaws.services.neptune.auth.LBAwareAwsSigV4ClientHandshaker;
+import io.netty.channel.ChannelHandler;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.apache.tinkerpop.gremlin.driver.handler.WebSocketClientHandler;
+import org.junit.Test;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class LBAwareSigV4WebSocketChannelizerTest  {
+    @Test
+    public void configureShouldAddSigV4HandshakerToPipeline() throws URISyntaxException {
+        ChannelPipeline mockedPipeline = new EmbeddedChannel().pipeline();
+        LBAwareSigV4WebSocketChannelizer channelizer = new LBAwareSigV4WebSocketChannelizer();
+        Connection mockedConnection = mock(Connection.class);
+        Cluster mockedCluster = mock(Cluster.class);
+
+        when(mockedConnection.getCluster()).thenReturn(mockedCluster);
+        when(mockedConnection.getUri()).thenReturn(new URI("ws:localhost"));
+
+        when(mockedCluster.connectionPoolSettings()).thenReturn(mock(Settings.ConnectionPoolSettings.class));
+        when(mockedCluster.authProperties()).thenReturn(new AuthProperties().with(AuthProperties.Property.JAAS_ENTRY, new HandshakeRequestConfig(Collections.emptyList(), 8182, false).value()));
+
+        channelizer.init(mockedConnection);
+        channelizer.configure(mockedPipeline);
+        ChannelHandler handler = mockedPipeline.get(LBAwareSigV4WebSocketChannelizer.WEB_SOCKET_HANDLER);
+
+        assertTrue(handler instanceof WebSocketClientHandler);
+        assertTrue(((WebSocketClientHandler) handler).handshaker() instanceof LBAwareAwsSigV4ClientHandshaker);
+    }
+}


### PR DESCRIPTION
Issue #, if available: #32

Description of changes:
Upgrading to TinkerPop 3.6.2 and adding tests. Upgrade involves replacing the use of `SigV4WebSocketChannelizer` with IAM connections with the more modern handshake interceptor approach from https://docs.aws.amazon.com/neptune/latest/userguide/iam-auth-connecting-gremlin-java.html.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

