### PR TITLE
Support Cross AWS Account Exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### New Features and Improvements:
 
+- Cross Account Exports: New CLI options and parameters added to specify a role to assume when uploading to
+Amazon S3 buckets or Amazon Kinesis Data Streams
+- New --credentials-profile CLI option to fetch AWS Credentials from non-default AWS CLI profiles
+
 ## Neptune Export v1.0.6 (Release Date: July 31, 2023):
 
 ### Bug Fixes:

--- a/docs/create-pg-config.md
+++ b/docs/create-pg-config.md
@@ -30,7 +30,9 @@
                     [ {-s | --scope} <scope> ] [ --sample ]
                     [ --sample-size <sampleSize> ] [ --serializer <serializer> ]
                     [ --stream-large-record-strategy <largeStreamRecordHandlingStrategy> ]
-                    [ --stream-name <streamName> ] [ {-t | --tag} <tag> ]
+                    [ --stream-name <streamName> ] [ --stream-role-arn <streamRoleArn> ]
+                    [ --stream-role-external-id <streamRoleExternalId> ]
+                    [ --stream-role-session-name <streamRoleSessionName> ] [ {-t | --tag} <tag> ]
                     [ --tokens-only <tokensOnly> ] [ --use-iam-auth ] [ --use-ssl ]
     
     OPTIONS
@@ -413,6 +415,26 @@
     
                 This option may occur a maximum of 1 times
     
+
+            --stream-role-arn <streamRoleArn>
+                Role to be assumed when uploading results to an Amazon Kinesis Data Stream.
+                If this options is unused, upload to Kinesis will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-external-id <streamRoleExternalId>
+                External Id to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-session-name <streamRoleSessionName>
+                Session name to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
     
             -t <tag>, --tag <tag>
                 Directory prefix (optional).

--- a/docs/export-pg-from-config.md
+++ b/docs/export-pg-from-config.md
@@ -39,7 +39,9 @@
                     [ {-s | --scope} <scope> ] [ --serializer <serializer> ]
                     [ --skip <skip> ]
                     [ --stream-large-record-strategy <largeStreamRecordHandlingStrategy> ]
-                    [ --stream-name <streamName> ] [ --strict-cardinality ]
+                    [ --stream-name <streamName> ] [ --stream-role-arn <streamRoleArn> ]
+                    [ --stream-role-external-id <streamRoleExternalId> ]
+                    [ --stream-role-session-name <streamRoleSessionName> ] [ --strict-cardinality ]
                     [ {-t | --tag} <tag> ] [ --token-prefix <tokenPrefix> ]
                     [ --tokens-only <tokensOnly> ] [ --use-iam-auth ] [ --use-ssl ]
     
@@ -484,7 +486,27 @@
     
                 This option may occur a maximum of 1 times
     
+
+            --stream-role-arn <streamRoleArn>
+                Role to be assumed when uploading results to an Amazon Kinesis Data Stream.
+                If this options is unused, upload to Kinesis will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-external-id <streamRoleExternalId>
+                External Id to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-session-name <streamRoleSessionName>
+                Session name to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
     
+
             --strict-cardinality
                 Format all set and list cardinality properties as arrays in JSON,
                 including properties with a single value (optional, default

--- a/docs/export-pg-from-queries.md
+++ b/docs/export-pg-from-queries.md
@@ -25,7 +25,9 @@
                     [ {--region | --stream-region} <region> ]
                     [ --serializer <serializer> ]
                     [ --stream-large-record-strategy <largeStreamRecordHandlingStrategy> ]
-                    [ --stream-name <streamName> ] [ {-t | --tag} <tag> ]
+                    [ --stream-name <streamName> ] [ --stream-role-arn <streamRoleArn> ]
+                    [ --stream-role-external-id <streamRoleExternalId> ]
+                    [ --stream-role-session-name <streamRoleSessionName> ] [ {-t | --tag} <tag> ]
                     [ --timeout-millis <timeoutMillis> ] [ --two-pass-analysis ]
                     [ --use-iam-auth ] [ --use-ssl ]
     
@@ -366,6 +368,26 @@
     
                 This option may occur a maximum of 1 times
     
+
+            --stream-role-arn <streamRoleArn>
+                Role to be assumed when uploading results to an Amazon Kinesis Data Stream.
+                If this options is unused, upload to Kinesis will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-external-id <streamRoleExternalId>
+                External Id to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-session-name <streamRoleSessionName>
+                Session name to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
     
             -t <tag>, --tag <tag>
                 Directory prefix (optional).

--- a/docs/export-pg.md
+++ b/docs/export-pg.md
@@ -40,7 +40,9 @@
                     [ {-s | --scope} <scope> ] [ --serializer <serializer> ]
                     [ --skip <skip> ]
                     [ --stream-large-record-strategy <largeStreamRecordHandlingStrategy> ]
-                    [ --stream-name <streamName> ] [ --strict-cardinality ]
+                    [ --stream-name <streamName> ] [ --stream-role-arn <streamRoleArn> ]
+                    [ --stream-role-external-id <streamRoleExternalId> ]
+                    [ --stream-role-session-name <streamRoleSessionName> ] [ --strict-cardinality ]
                     [ {-t | --tag} <tag> ] [ --token-prefix <tokenPrefix> ]
                     [ --tokens-only <tokensOnly> ] [ --use-iam-auth ] [ --use-ssl ]
     
@@ -491,7 +493,27 @@
                 Name of an Amazon Kinesis Data Stream.
     
                 This option may occur a maximum of 1 times
-    
+
+
+            --stream-role-arn <streamRoleArn>
+                Role to be assumed when uploading results to an Amazon Kinesis Data Stream.
+                If this options is unused, upload to Kinesis will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-external-id <streamRoleExternalId>
+                External Id to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-session-name <streamRoleSessionName>
+                Session name to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
     
             --strict-cardinality
                 Format all set and list cardinality properties as arrays in JSON,

--- a/docs/export-rdf.md
+++ b/docs/export-rdf.md
@@ -19,9 +19,11 @@
                     [ --profile <profiles>... ] [ --rdf-export-scope <scope> ]
                     [ {--region | --stream-region} <region> ] [ --sparql <query> ]
                     [ --stream-large-record-strategy <largeStreamRecordHandlingStrategy> ]
-                    [ --stream-name <streamName> ] [ {-t | --tag} <tag> ]
-                    [ --use-iam-auth ] [ --use-ssl ]
-    
+                    [ --stream-name <streamName> ] [ --stream-role-arn <streamRoleArn> ]
+                    [ --stream-role-external-id <streamRoleExternalId> ]
+                    [ --stream-role-session-name <streamRoleSessionName> ]
+                    [ {-t | --tag} <tag> ] [ --use-iam-auth ] [ --use-ssl ]
+
     OPTIONS
             --alb-endpoint <applicationLoadBalancerEndpoint>
                 Application load balancer endpoint (optional: use only if
@@ -310,7 +312,27 @@
     
                 This option may occur a maximum of 1 times
     
-    
+
+            --stream-role-arn <streamRoleArn>
+                Role to be assumed when uploading results to an Amazon Kinesis Data Stream.
+                If this options is unused, upload to Kinesis will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-external-id <streamRoleExternalId>
+                External Id to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times
+
+
+            --stream-role-session-name <streamRoleSessionName>
+                Session name to be used when assuming the role defined by --stream-role-arn
+
+                This option may occur a maximum of 1 times    
+
+
             -t <tag>, --tag <tag>
                 Directory prefix (optional).
     

--- a/docs/export-service.md
+++ b/docs/export-service.md
@@ -1,0 +1,159 @@
+    NAME
+            neptune-export.sh export-svc - Use Neptune Export Service to manage Export Job.
+            Can optionally copy results to an Amazon S3 bucket.
+    
+    SYNOPSIS
+            neptune-export.sh nesvc
+                    --root-path
+                    --json
+
+    
+    OPTIONS
+            --json
+                A json object describing the export job to be performed (see JSON SYNOPSIS and JSON OPTIONS)
+
+                This option must occur exactly 1 time
+
+
+            --root-path
+                Root directory for output.
+    
+                This option must occur exactly 1 time
+
+                This options value must be a path to a directory. The provided path
+                must be readable and writable.
+           
+
+    JSON SYNOPSIS
+            --json '{
+                        "command" : <command>,
+                        "params" : <params>,
+                        [ "additionalParams" : <additionalParams>, ]
+                        [ "completionFilePayload" : <completionFilePayload>, ]
+                        [ "completionFileS3Path" : <completionFileS3Path>, ]
+                        [ "configFileS3Path" : <configFileS3Path>, ]
+                        [ "createExportSubdirectory" : <createExportSubdirectory>, ]
+                        [ "jobSize" : <jobSize>, ]
+                        [ "outputS3Path" : <outputS3Path>, ]
+                        [ "overwriteExisting" : <overwriteExisting>, ]
+                        [ "queriesFileS3Path" : <queriesFileS3Path>, ]
+                        [ "s3Region" : <s3Region>, ]
+                        [ "s3RoleArn" : <s3RoleArn>, ]
+                        [ "s3RoleExternalId" : <s3RoleExternalId>, ]
+                        [ "s3RoleSessionName":  <s3RoleSessionName>, ]
+                        [ "sseKmsKeyId" : <sseKmsKeyId>, ]
+                        [ "uploadToS3OnError" : <uploadToS3OnError>, ]
+                    }'
+
+
+    JSON OPTIONS
+            "command" : <command>
+                The Neptune Export command to be executed by the service. Must be one of
+                "export-pg", "export-rdf", "export-pg-from-queries", "export-pg-from-comfig",
+                "create-pg-config", "add-clone", "remove-clone"
+
+                This option must occur exactly 1 time
+
+
+            "params" : <params>
+                A JSON object containing parameter mappings to be passed to the internal export job.
+                All of the CLI options for the underlying export command can be included, although the
+                parameter name should be translated to camelCase (--clone-cluster becomes "cloneCluster").
+
+                Eg.
+                    "params": {
+                        "endpoint" : "(your Neptune endpoint DNS name)",
+                        "cloneCluser" : true,
+                        "format" : "csv"
+                    }
+                
+                This option must occur exactly 1 time
+
+
+            "additionalParams" : <additionalParams>
+                Additional parameters to be used in conjunction with a Neptune ML export. See
+                https://docs.aws.amazon.com/neptune/latest/userguide/machine-learning-data-export.html#machine-learning-additionalParams for more details.
+
+                This option must occur exactly 1 time
+
+
+            "completionFilePayload" : <completionFilePayload>
+                Payload to be used when writing completion file.
+
+                This option may occur a maximum of 1 times
+
+
+            "completionFileS3Path" : <completionFileS3Path>
+                Amazon S3 file path for a completion file.
+
+                This option may occur a maximum of 1 times
+
+
+            "configFileS3Path" : <configFileS3Path>
+                Amazon S3 file path pointing to a config file.
+
+                This option may occur a maximum of 1 times
+
+
+            "createExportSubdirectory" : <createExportSubdirectory>
+                If enabled, Neptune Export will create a subdirectory with a random identifier
+                in the target Amazon S3 bucket. Defaults to true.
+                
+                This option may occur a maximum of 1 times
+
+
+            "outputS3Path" : <outputS3Path>
+                S3 URI for a target Amazon S3 bucket. Eg. s3://example-bucket/example-dir/
+
+                This option may occur a maximum of 1 times
+
+
+            "overwriteExisting" : <overwriteExisting>
+                If set to true, any existing contents in the target Amazon S3 bucket will
+                be overwritten. Defaults to false.
+
+                This option may occur a maximum of 1 times
+
+
+            "queriesFileS3Path" : <queriesFileS3Path>
+                Amazon S3 file path pointing to a queries file.
+
+                This option may occur a maximum of 1 times
+
+
+            "s3Region" : <s3Region>
+                Amazon S3 bucket region.
+
+                This option may occur a maximum of 1 times
+
+
+            "s3RoleArn" : <s3RoleArn>
+                Role to be assumed when uploading results to an Amazon S3 bucket.
+                If this options is unused, upload to S3 bucket will use credentials found by
+                the DefaultAWSCredentialsProviderChain.
+
+                This option may occur a maximum of 1 times
+
+
+            "s3RoleExternalId" : <s3RoleExternalId>
+                External Id to be used when assuming the role defined by s3RoleArn
+
+                This option may occur a maximum of 1 times
+
+
+            "s3RoleSessionName" : <s3RoleSessionName>
+                Session name to be used when assuming the role defined by s3RoleArn
+
+                This option may occur a maximum of 1 times
+
+
+            "sseKmsKeyId" : <sseKmsKeyId>
+                sseKmsKeyId to be used with the Amazon S3 bucket.
+
+                This option may occur a maximum of 1 times
+
+
+            "uploadToS3OnError" : <uploadToS3OnError>
+                Set as True to upload partial results to Amazon S3 if the export job fails 
+
+                This option may occur a maximum of 1 times

--- a/src/main/java/com/amazonaws/services/neptune/cli/CommonConnectionModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/CommonConnectionModule.java
@@ -21,11 +21,15 @@ import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.*;
 import org.apache.commons.lang.StringUtils;
 
+import javax.inject.Inject;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.function.Supplier;
 
 public class CommonConnectionModule {
+
+    @Inject
+    private CredentialProfileModule credentialProfileModule = new CredentialProfileModule();
 
     @Option(name = {"-e", "--endpoint"}, description = "Neptune endpoint(s) – supply multiple instance endpoints if you want to load balance requests across a cluster.", title = "endpoint")
     @RequireSome(tag = "endpoint or clusterId")
@@ -123,7 +127,8 @@ public class CommonConnectionModule {
                 port,
                 useIamAuth,
                 !disableSsl,
-                proxyConfig
+                proxyConfig,
+                credentialProfileModule.getCredentialsProvider()
         );
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/cli/CredentialProfileModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/CredentialProfileModule.java
@@ -1,0 +1,33 @@
+package com.amazonaws.services.neptune.cli;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.regions.AwsProfileRegionProvider;
+import com.amazonaws.regions.AwsRegionProvider;
+import com.amazonaws.regions.AwsRegionProviderChain;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.services.neptune.util.AWSCredentialsUtil;
+import com.github.rvesse.airline.annotations.Option;
+import com.github.rvesse.airline.annotations.restrictions.Once;
+import org.apache.commons.lang.StringUtils;
+
+public class CredentialProfileModule {
+    @Option(name = {"--credentials-profile"}, description = "Use profile from credentials config file.", hidden = true)
+    @Once
+    private String credentialsProfile;
+
+    @Option(name = {"--credentials-config-file"}, description = "Load credentials profile from specified config file.", hidden = true)
+    @Once
+    private String credentialsConfigFilePath;
+
+    public AWSCredentialsProvider getCredentialsProvider() {
+        return AWSCredentialsUtil.getProfileCredentialsProvider(credentialsProfile, credentialsConfigFilePath);
+    }
+
+    public AwsRegionProvider getRegionProvider() {
+        if(StringUtils.isEmpty(credentialsProfile)) {
+            return new DefaultAwsRegionProviderChain();
+        }
+        return new AwsRegionProviderChain(new AwsProfileRegionProvider(credentialsProfile), new DefaultAwsRegionProviderChain());
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/neptune/cli/RdfTargetModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/RdfTargetModule.java
@@ -18,9 +18,6 @@ import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.*;
 
-import java.io.IOException;
-import java.util.UUID;
-
 public class RdfTargetModule extends AbstractTargetModule {
 
     @Option(name = {"--format"}, description = "Output format (optional, default 'turtle').")

--- a/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -80,7 +80,10 @@ public class CloneCluster implements CloneClusterStrategy {
                         targetClusterId,
                         targetClusterMetadata.endpoints(),
                         connectionConfig.port(),
-                        targetClusterMetadata.isIAMDatabaseAuthenticationEnabled(), true, connectionConfig.proxyConfig()
+                        targetClusterMetadata.isIAMDatabaseAuthenticationEnabled(),
+                        true,
+                        connectionConfig.proxyConfig(),
+                        connectionConfig.getCredentialsProvider()
                 ),
                 new ConcurrencyConfig(newConcurrency),
                 targetClusterMetadata

--- a/src/main/java/com/amazonaws/services/neptune/cluster/ConnectionConfig.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/ConnectionConfig.java
@@ -12,8 +12,9 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.cluster;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.neptune.auth.HandshakeRequestConfig;
-import org.apache.commons.lang.StringUtils;
 
 import java.util.Collection;
 import java.util.Collections;
@@ -26,17 +27,27 @@ public class ConnectionConfig {
     private final boolean useIamAuth;
     private boolean useSsl;
     private final ProxyConfig proxyConfig;
+    private final AWSCredentialsProvider credentialsProvider;
 
     public ConnectionConfig(String clusterId,
                             Collection<String> neptuneEndpoints,
                             int neptunePort,
                             boolean useIamAuth, boolean useSsl, ProxyConfig proxyConfig) {
+        this(clusterId, neptuneEndpoints, neptunePort, useIamAuth, useSsl, proxyConfig, new DefaultAWSCredentialsProviderChain());
+    }
+
+    public ConnectionConfig(String clusterId,
+                            Collection<String> neptuneEndpoints,
+                            int neptunePort,
+                            boolean useIamAuth, boolean useSsl, ProxyConfig proxyConfig,
+                            AWSCredentialsProvider credentialsProvider) {
         this.clusterId = clusterId;
         this.neptuneEndpoints = neptuneEndpoints;
         this.neptunePort = neptunePort;
         this.useIamAuth = useIamAuth;
         this.useSsl = useSsl;
         this.proxyConfig = proxyConfig;
+        this.credentialsProvider = credentialsProvider;
     }
 
     public Collection<String> endpoints() {
@@ -77,5 +88,9 @@ public class ConnectionConfig {
 
     public ProxyConfig proxyConfig() {
         return proxyConfig;
+    }
+
+    public AWSCredentialsProvider getCredentialsProvider() {
+        return credentialsProvider;
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/io/KinesisConfig.java
+++ b/src/main/java/com/amazonaws/services/neptune/io/KinesisConfig.java
@@ -63,6 +63,7 @@ public class KinesisConfig {
                             .setConnectTimeout(12000)
                             .setRequestTimeout(12000)
                             .setRecordTtl(Integer.MAX_VALUE)
+                            .setCredentialsProvider(targetModule.getCredentialsProvider())
                     ),
                     targetModule.getStreamName(),
                     targetModule.getLargeStreamRecordHandlingStrategy());

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
@@ -13,7 +13,6 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazon.neptune.gremlin.driver.sigv4.ChainedSigV4PropertiesProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneNettyHttpSigV4Signer;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import com.amazonaws.services.neptune.cluster.Cluster;
@@ -70,7 +69,7 @@ public class NeptuneGremlinClient implements AutoCloseable {
                             NeptuneNettyHttpSigV4Signer sigV4Signer =
                                     new NeptuneNettyHttpSigV4Signer(
                                             new ChainedSigV4PropertiesProvider().getSigV4Properties().getServiceRegion(),
-                                            new DefaultAWSCredentialsProviderChain());
+                                            connectionConfig.getCredentialsProvider());
                             sigV4Signer.signRequest(r);
                         } catch (NeptuneSigV4SignerException e) {
                             throw new RuntimeException("Exception occurred while signing the request", e);

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -13,17 +13,13 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.rdf;
 
 import com.amazonaws.auth.AWSCredentialsProvider;
-import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import com.amazonaws.services.neptune.cluster.ConnectionConfig;
 import com.amazonaws.services.neptune.io.OutputWriter;
 import com.amazonaws.services.neptune.rdf.io.NeptuneExportSparqlRepository;
 import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.amazonaws.services.neptune.util.EnvironmentVariableUtils;
-import org.apache.http.Header;
 import org.apache.http.client.HttpClient;
-import org.apache.http.conn.EofSensorInputStream;
-import org.apache.http.impl.io.ChunkedInputStream;
 import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
 import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
@@ -48,7 +44,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
     public static NeptuneSparqlClient create(ConnectionConfig config) {
 
         String serviceRegion = config.useIamAuth() ? EnvironmentVariableUtils.getMandatoryEnv("SERVICE_REGION") : null;
-        AWSCredentialsProvider credentialsProvider = config.useIamAuth() ? new DefaultAWSCredentialsProviderChain() : null;
+        AWSCredentialsProvider credentialsProvider = config.useIamAuth() ? config.getCredentialsProvider() : null;
 
         return new NeptuneSparqlClient(
                 config.endpoints().stream()

--- a/src/main/java/com/amazonaws/services/neptune/util/AWSCredentialsUtil.java
+++ b/src/main/java/com/amazonaws/services/neptune/util/AWSCredentialsUtil.java
@@ -1,0 +1,57 @@
+package com.amazonaws.services.neptune.util;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.auth.STSAssumeRoleSessionCredentialsProvider;
+import com.amazonaws.auth.profile.ProfileCredentialsProvider;
+import com.amazonaws.regions.DefaultAwsRegionProviderChain;
+import com.amazonaws.services.securitytoken.AWSSecurityTokenServiceClient;
+
+import org.apache.commons.lang.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class AWSCredentialsUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(AWSCredentialsUtil.class);
+
+    public static AWSCredentialsProvider getProfileCredentialsProvider(String profileName, String profilePath) {
+        if (StringUtils.isEmpty(profileName) && StringUtils.isEmpty(profilePath)) {
+            return new DefaultAWSCredentialsProviderChain();
+        }
+        if (StringUtils.isEmpty(profilePath)) {
+            logger.debug(String.format("Using ProfileCredentialsProvider with profile: %s", profileName));
+            return new ProfileCredentialsProvider(profileName);
+        }
+        logger.debug(String.format("Using ProfileCredentialsProvider with profile: %s and credentials file: ", profileName, profilePath));
+        return new ProfileCredentialsProvider(profilePath, profileName);
+    }
+
+    public static AWSCredentialsProvider getSTSAssumeRoleCredentialsProvider(String roleARN, String sessionName, String externalId) {
+        return getSTSAssumeRoleCredentialsProvider(roleARN, sessionName, externalId, new DefaultAWSCredentialsProviderChain());
+    }
+
+    public static AWSCredentialsProvider getSTSAssumeRoleCredentialsProvider(String roleARN,
+                                                                             String sessionName,
+                                                                             String externalId,
+                                                                             AWSCredentialsProvider sourceCredentialsProvider) {
+        return getSTSAssumeRoleCredentialsProvider(roleARN, sessionName, externalId, sourceCredentialsProvider,
+                new DefaultAwsRegionProviderChain().getRegion());
+    }
+
+    public static AWSCredentialsProvider getSTSAssumeRoleCredentialsProvider(String roleARN,
+                                                                             String sessionName,
+                                                                             String externalId,
+                                                                             AWSCredentialsProvider sourceCredentialsProvider,
+                                                                             String region) {
+        STSAssumeRoleSessionCredentialsProvider.Builder providerBuilder = new STSAssumeRoleSessionCredentialsProvider.Builder(roleARN, sessionName)
+                .withStsClient(
+                        AWSSecurityTokenServiceClient.builder().withCredentials(sourceCredentialsProvider).withRegion(region).build());
+        if (externalId != null) {
+            providerBuilder = providerBuilder.withExternalId(externalId);
+        }
+        logger.debug(String.format("Assuming Role: %s with session name: %s", roleARN, sessionName));
+        return providerBuilder.build();
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/neptune/util/TransferManagerWrapper.java
+++ b/src/main/java/com/amazonaws/services/neptune/util/TransferManagerWrapper.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.util;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.transfer.TransferManager;
 import com.amazonaws.services.s3.transfer.TransferManagerBuilder;
@@ -22,8 +23,15 @@ public class TransferManagerWrapper implements AutoCloseable {
     private final TransferManager transferManager;
 
     public TransferManagerWrapper(String s3Region) {
+        this(s3Region, null);
+    }
+
+    public TransferManagerWrapper(String s3Region, AWSCredentialsProvider credentialsProvider) {
 
         AmazonS3ClientBuilder amazonS3ClientBuilder = AmazonS3ClientBuilder.standard();
+        if (credentialsProvider != null) {
+            amazonS3ClientBuilder = amazonS3ClientBuilder.withCredentials(credentialsProvider);
+        }
 
         if (StringUtils.isNotEmpty(s3Region)) {
             amazonS3ClientBuilder = amazonS3ClientBuilder.withRegion(s3Region);

--- a/src/test/java/com/amazonaws/services/neptune/io/KinesisConfigTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/io/KinesisConfigTest.java
@@ -1,14 +1,18 @@
 package com.amazonaws.services.neptune.io;
 
+import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.neptune.cli.AbstractTargetModule;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 public class KinesisConfigTest {
@@ -47,5 +51,18 @@ public class KinesisConfigTest {
 
         Throwable t = assertThrows(IllegalArgumentException.class, () -> config.stream());
         assertEquals("You must supply an AWS Region and Amazon Kinesis Data Stream name", t.getMessage());
+    }
+
+    @Test
+    public void shouldUseProvidedCredentialsProvider() {
+        when(target.getStreamName()).thenReturn("test");
+        when(target.getRegion()).thenReturn("us-west-2");
+        AWSCredentialsProvider mockedCredsProvider = mock(AWSCredentialsProvider.class);
+        when(target.getCredentialsProvider()).thenReturn(mockedCredsProvider);
+
+        KinesisConfig config = new KinesisConfig(target);
+        config.stream().publish("test");
+
+        verify(mockedCredsProvider, Mockito.atLeast(1)).getCredentials();
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/util/AWSCredentialsUtilTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/util/AWSCredentialsUtilTest.java
@@ -1,0 +1,73 @@
+package com.amazonaws.services.neptune.util;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
+import com.amazonaws.services.securitytoken.model.AWSSecurityTokenServiceException;
+import org.junit.Before;
+
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.IOException;
+
+import static com.amazonaws.services.neptune.util.AWSCredentialsUtil.getProfileCredentialsProvider;
+import static com.amazonaws.services.neptune.util.AWSCredentialsUtil.getSTSAssumeRoleCredentialsProvider;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+public class AWSCredentialsUtilTest {
+
+    TemporaryFolder tempFolder;
+    File credentialsFile;
+
+    @Before
+    public void setup() throws IOException {
+        tempFolder = new TemporaryFolder();
+        tempFolder.create();
+        credentialsFile = tempFolder.newFile("credentialsFile");
+    }
+
+    @Test
+    public void shouldGetDefaultCredsIfConfigIsNull() {
+        AWSCredentialsProvider provider = getProfileCredentialsProvider(null, null);
+        assertTrue(provider instanceof DefaultAWSCredentialsProviderChain);
+    }
+
+    @Test
+    public void shouldAttemptToUseProvidedPath() {
+        Throwable t = assertThrows(IllegalArgumentException.class, () -> getProfileCredentialsProvider(
+                null, tempFolder.getRoot().getAbsolutePath()+"/non-existent-file").getCredentials());
+        assertEquals("AWS credential profiles file not found in the given path: "+
+                tempFolder.getRoot().getAbsolutePath()+"/non-existent-file", t.getMessage());
+    }
+
+    @Test
+    public void shouldUseDefaultCredsIfProfileNameNull() {
+        Throwable t = assertThrows(IllegalArgumentException.class, () -> getProfileCredentialsProvider(
+                null, credentialsFile.getAbsolutePath()).getCredentials());
+        assertTrue(t.getMessage().contains("No AWS profile named 'default'"));
+    }
+
+    @Test
+    public void shouldAttemptToUseProvidedProfileName() {
+        Throwable t = assertThrows(IllegalArgumentException.class, () -> getProfileCredentialsProvider(
+                "test", credentialsFile.getAbsolutePath()).getCredentials());
+        assertTrue(t.getMessage().contains("No AWS profile named 'test'"));
+    }
+
+    @Test
+    public void shouldUseSourceCredsProviderWhenAssumingRole() {
+        AWSCredentialsProvider mockSourceCredsProvider = mock(AWSCredentialsProvider.class);
+        try {
+            getSTSAssumeRoleCredentialsProvider("fakeARN", "sessionName", null, mockSourceCredsProvider, "us-west-2")
+                    .getCredentials();
+        }
+        catch (AWSSecurityTokenServiceException e) {} //Expected to fail as sourceCredsProvider does not have permission to assume role
+
+        Mockito.verify(mockSourceCredsProvider, Mockito.atLeast(1)).getCredentials();
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/util/TransferManagerWrapperTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/util/TransferManagerWrapperTest.java
@@ -1,0 +1,43 @@
+package com.amazonaws.services.neptune.util;
+
+import com.amazonaws.SdkClientException;
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.auth.AnonymousAWSCredentials;
+import org.junit.Test;
+import org.mockito.internal.verification.AtLeast;
+
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TransferManagerWrapperTest {
+
+    private final String REGION = "us-west-2";
+    @Test
+    public void shouldHandleNullCredentialsProvider() {
+        TransferManagerWrapper wrapper = new TransferManagerWrapper(REGION, null);
+        assertNotNull(wrapper);
+        assertNotNull(wrapper.get());
+        assertNotNull(wrapper.get().getAmazonS3Client());
+    }
+
+    @Test
+    public void shouldUseProvidedCredentials() {
+        AWSCredentialsProvider mockCredentialsProvider = mock(AWSCredentialsProvider.class);
+        when(mockCredentialsProvider.getCredentials()).thenReturn(new AnonymousAWSCredentials());
+
+        TransferManagerWrapper wrapper = new TransferManagerWrapper(REGION, mockCredentialsProvider);
+        assertNotNull(wrapper);
+        assertNotNull(wrapper.get());
+        assertNotNull(wrapper.get().getAmazonS3Client());
+
+        //Expected to fail due to invalid credentials. This call is here to force the S3 client to call getCredentials()
+        try {
+            wrapper.get().getAmazonS3Client().listBuckets();
+        }
+        catch (SdkClientException e) {}
+
+        verify(mockCredentialsProvider, new AtLeast(1)).getCredentials();
+    }
+}


### PR DESCRIPTION
Issue #, if available: #12, #16

Description of changes:

Adds ability to assume a role for target uploads to either S3 or Kinesis

Adds --credentials-profile CLI argument to use a credential profile defined in the AWS CLI as opposed to the default profile.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

