### PR TITLE
Add TruffleHog Secrets Scan to CI

### DIFF
--- a/.github/workflows/maven_build_and_verify.yml
+++ b/.github/workflows/maven_build_and_verify.yml
@@ -48,3 +48,18 @@ jobs:
 
     - name: Upload coverage to Codecov
       uses: codecov/codecov-action@v3
+
+  TruffleHog:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: TruffleHog OSS
+        uses: trufflesecurity/trufflehog@main
+        with:
+          path: ./
+          base: ${{ github.event.repository.default_branch }}
+          head: HEAD
+          extra_args: --debug --only-verified

--- a/.github/workflows/maven_build_and_verify.yml
+++ b/.github/workflows/maven_build_and_verify.yml
@@ -63,3 +63,6 @@ jobs:
           base: ${{ github.event.repository.default_branch }}
           head: HEAD
           extra_args: --debug --only-verified
+      - name: Scan Results Status
+        if: steps.trufflehog.outcome == 'failure'
+        run: exit 1


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Add trufflehog to CI to detect PR's which leak credentials in source code

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

