### PR TITLE
Queries-based Exports Structured Output for nodes

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/AllLabels.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/AllLabels.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
@@ -59,6 +60,11 @@ public class AllLabels implements LabelsFilter {
 
     @Override
     public Label getLabelFor(Map<String, Object> input) {
+        return labelStrategy.getLabelFor(input);
+    }
+
+    @Override
+    public Label getLabelFor(PGResult input) {
         return labelStrategy.getLabelFor(input);
     }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgeLabelStrategy.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgeLabelStrategy.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.propertygraph;
 
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -20,7 +21,10 @@ import org.apache.tinkerpop.gremlin.structure.Element;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.*;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 
@@ -43,6 +47,11 @@ public enum EdgeLabelStrategy implements LabelStrategy {
         @Override
         public Label getLabelFor(Map<String, Object> input) {
             return new Label(input.get("~label").toString());
+        }
+
+        @Override
+        public Label getLabelFor(PGResult input) {
+            return new Label(input.getLabel());
         }
 
         @Override
@@ -84,6 +93,14 @@ public enum EdgeLabelStrategy implements LabelStrategy {
             String label = String.valueOf(input.get("~label"));
             @SuppressWarnings("unchecked")
             Collection<String> toLabels = (Collection<String>) input.get("~toLabels");
+            return new Label(label, fromLabels, toLabels);
+        }
+
+        @Override
+        public Label getLabelFor(PGResult input) {
+            Collection<String> fromLabels = input.getFromLabels();
+            String label = input.getLabel().get(0);
+            Collection<String> toLabels = input.getToLabels();
             return new Label(label, fromLabels, toLabels);
         }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgesClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/EdgesClient.java
@@ -15,6 +15,8 @@ package com.amazonaws.services.neptune.propertygraph;
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.propertygraph.io.GraphElementHandler;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import com.amazonaws.services.neptune.util.Activity;
@@ -35,7 +37,7 @@ import java.util.Map;
 
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 
-public class EdgesClient implements GraphClient<Map<String, Object>> {
+public class EdgesClient implements GraphClient<PGResult> {
 
     private static final Logger logger = LoggerFactory.getLogger(EdgesClient.class);
 
@@ -77,7 +79,7 @@ public class EdgesClient implements GraphClient<Map<String, Object>> {
     }
 
     @Override
-    public void queryForValues(GraphElementHandler<Map<String, Object>> handler,
+    public void queryForValues(GraphElementHandler<PGResult> handler,
                                Range range,
                                LabelsFilter labelsFilter,
                                GremlinFilters gremlinFilters,
@@ -112,7 +114,7 @@ public class EdgesClient implements GraphClient<Map<String, Object>> {
                 if (featureToggles.containsFeature(FeatureToggle.Inject_Fault)){
                     throw new IllegalStateException("Simulated fault in EdgesClient");
                 }
-                handler.handle(p, false);
+                handler.handle(new PGEdgeResult(p), false);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -157,7 +159,7 @@ public class EdgesClient implements GraphClient<Map<String, Object>> {
     }
 
     @Override
-    public Label getLabelFor(Map<String, Object> input, LabelsFilter labelsFilter) {
+    public Label getLabelFor(PGResult input, LabelsFilter labelsFilter) {
         return labelsFilter.getLabelFor(input);
     }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/LabelStrategy.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/LabelStrategy.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.propertygraph;
 
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -23,6 +24,8 @@ public interface LabelStrategy {
     Collection<Label> getLabels(GraphTraversalSource g);
 
     Label getLabelFor(Map<String, Object> input);
+
+    Label getLabelFor(PGResult input);
 
     String[] additionalColumns(String... columns);
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/LabelsFilter.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/LabelsFilter.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -30,6 +31,8 @@ public interface LabelsFilter {
     String[] getPropertiesForLabels(GraphElementSchemas graphElementSchemas);
 
     Label getLabelFor(Map<String, Object> input);
+
+    Label getLabelFor(PGResult result);
 
     String[] addAdditionalColumnNames(String... columns);
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/NodeLabelStrategy.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/NodeLabelStrategy.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.propertygraph;
 
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 import org.apache.tinkerpop.gremlin.structure.Element;
@@ -41,6 +42,14 @@ public enum NodeLabelStrategy implements LabelStrategy {
         public Label getLabelFor(Map<String, Object> input) {
             @SuppressWarnings("unchecked")
             List<String> labels = (List<String>) input.get("~label");
+            labels = Label.fixLabelsIssue(labels);
+
+            return new Label(labels);
+        }
+
+        @Override
+        public Label getLabelFor(PGResult input) {
+            List<String> labels = input.getLabel();
             labels = Label.fixLabelsIssue(labels);
 
             return new Label(labels);

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/NodesClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/NodesClient.java
@@ -15,6 +15,8 @@ package com.amazonaws.services.neptune.propertygraph;
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.propertygraph.io.GraphElementHandler;
+import com.amazonaws.services.neptune.propertygraph.io.result.ExportPGNodeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import com.amazonaws.services.neptune.util.Activity;
@@ -36,7 +38,7 @@ import java.util.Map;
 import static org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__.*;
 
 
-public class NodesClient implements GraphClient<Map<String, Object>> {
+public class NodesClient implements GraphClient<PGResult> {
 
     private static final Logger logger = LoggerFactory.getLogger(NodesClient.class);
 
@@ -82,7 +84,7 @@ public class NodesClient implements GraphClient<Map<String, Object>> {
     }
 
     @Override
-    public void queryForValues(GraphElementHandler<Map<String, Object>> handler,
+    public void queryForValues(GraphElementHandler<PGResult> handler,
                                Range range,
                                LabelsFilter labelsFilter,
                                GremlinFilters gremlinFilters,
@@ -110,7 +112,7 @@ public class NodesClient implements GraphClient<Map<String, Object>> {
                 if (featureToggles.containsFeature(FeatureToggle.Inject_Fault)){
                     throw new IllegalStateException("Simulated fault in NodesClient");
                 }
-                handler.handle(m, false);
+                handler.handle(new ExportPGNodeResult(m), false);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -156,7 +158,7 @@ public class NodesClient implements GraphClient<Map<String, Object>> {
     }
 
     @Override
-    public Label getLabelFor(Map<String, Object> input, LabelsFilter labelsFilter) {
+    public Label getLabelFor(PGResult input, LabelsFilter labelsFilter) {
         return labelsFilter.getLabelFor(input);
     }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/SpecifiedLabels.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/SpecifiedLabels.java
@@ -14,6 +14,7 @@ package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
@@ -140,6 +141,11 @@ public class SpecifiedLabels implements LabelsFilter {
 
     @Override
     public Label getLabelFor(Map<String, Object> input) {
+        return labelStrategy.getLabelFor(input);
+    }
+
+    @Override
+    public Label getLabelFor(PGResult input) {
         return labelStrategy.getLabelFor(input);
     }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CountingHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/CountingHandler.java
@@ -1,0 +1,28 @@
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import java.io.IOException;
+
+class CountingHandler<T> implements GraphElementHandler<T> {
+
+    private final GraphElementHandler<T> parent;
+    private long counter = 0;
+
+    CountingHandler(GraphElementHandler<T> parent) {
+        this.parent = parent;
+    }
+
+    @Override
+    public void handle(T input, boolean allowTokens) throws IOException {
+        parent.handle(input, allowTokens);
+        counter++;
+    }
+
+    long numberProcessed() {
+        return counter;
+    }
+
+    @Override
+    public void close() throws Exception {
+        parent.close();
+    }
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/EdgeWriter.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/EdgeWriter.java
@@ -14,11 +14,13 @@ package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
 import com.amazonaws.services.neptune.propertygraph.LabelsFilter;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 
 import java.io.IOException;
 import java.util.*;
 
-public class EdgeWriter implements LabelWriter<Map<String, Object>> {
+public class EdgeWriter implements LabelWriter<PGEdgeResult> {
 
     private final PropertyGraphPrinter propertyGraphPrinter;
     private final boolean hasFromAndToLabels;
@@ -29,21 +31,18 @@ public class EdgeWriter implements LabelWriter<Map<String, Object>> {
     }
 
     @Override
-    public void handle(Map<String, Object> map, boolean allowTokens) throws IOException {
-        String from = String.valueOf(map.get("~from"));
-        String to = String.valueOf(map.get("~to"));
-        @SuppressWarnings("unchecked")
-        Map<?, Object> properties = (Map<?, Object>) map.get("properties");
-        String id = String.valueOf(map.get("~id"));
-        String label = (String) map.get("~label");
+    public void handle(PGEdgeResult edge, boolean allowTokens) throws IOException {
+        String from = edge.getFrom();
+        String to = edge.getTo();
+        Map<?, Object> properties = edge.getProperties();
+        String id = edge.getId();
+        String label = edge.getLabel().get(0);
 
         propertyGraphPrinter.printStartRow();
 
         if (hasFromAndToLabels){
-            @SuppressWarnings("unchecked")
-            List<String> fromLabels = (List<String>) map.get("~fromLabels");
-            @SuppressWarnings("unchecked")
-            List<String> toLabels = (List<String>) map.get("~toLabels");
+            List<String> fromLabels = edge.getFromLabels();
+            List<String> toLabels = edge.getToLabels();
 
             // Temp fix for concatenated label issue
             fromLabels = Label.fixLabelsIssue(fromLabels);

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/EdgesWriterFactory.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/EdgesWriterFactory.java
@@ -13,12 +13,14 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
 
 import java.io.IOException;
 import java.util.Map;
 
-public class EdgesWriterFactory implements WriterFactory<Map<String, Object>> {
+public class EdgesWriterFactory implements WriterFactory<PGEdgeResult> {
 
     @Override
     public PropertyGraphPrinter createPrinter(String name, LabelSchema labelSchema, PropertyGraphTargetConfig targetConfig) throws IOException {
@@ -36,7 +38,7 @@ public class EdgesWriterFactory implements WriterFactory<Map<String, Object>> {
     }
 
     @Override
-    public LabelWriter<Map<String, Object>> createLabelWriter(PropertyGraphPrinter propertyGraphPrinter, Label label) {
+    public LabelWriter<PGEdgeResult> createLabelWriter(PropertyGraphPrinter propertyGraphPrinter, Label label) {
         return new EdgeWriter(propertyGraphPrinter, label);
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPGTaskHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPGTaskHandler.java
@@ -1,0 +1,93 @@
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.io.Directories;
+import com.amazonaws.services.neptune.io.Status;
+import com.amazonaws.services.neptune.propertygraph.GraphClient;
+import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.LabelsFilter;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.propertygraph.schema.FileSpecificLabelSchemas;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
+import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+class ExportPGTaskHandler<T extends PGResult> implements GraphElementHandler<T> {
+
+    private static final Logger logger = LoggerFactory.getLogger(ExportPGTaskHandler.class);
+
+    private final FileSpecificLabelSchemas fileSpecificLabelSchemas;
+    private final GraphElementSchemas graphElementSchemas;
+    private final PropertyGraphTargetConfig targetConfig;
+    private final WriterFactory<T> writerFactory;
+    private final LabelWriters<T> labelWriters;
+    private final GraphClient<T> graphClient;
+    private final Status status;
+    private final AtomicInteger index;
+
+    private final LabelsFilter labelsFilter;
+
+    ExportPGTaskHandler(FileSpecificLabelSchemas fileSpecificLabelSchemas,
+                        GraphElementSchemas graphElementSchemas,
+                        PropertyGraphTargetConfig targetConfig,
+                        WriterFactory<T> writerFactory,
+                        LabelWriters<T> labelWriters,
+                        GraphClient<T> graphClient,
+                        Status status,
+                        AtomicInteger index,
+                        LabelsFilter labelsFilter) {
+        this.fileSpecificLabelSchemas = fileSpecificLabelSchemas;
+        this.graphElementSchemas = graphElementSchemas;
+        this.targetConfig = targetConfig;
+        this.writerFactory = writerFactory;
+        this.labelWriters = labelWriters;
+        this.graphClient = graphClient;
+        this.status = status;
+        this.index = index;
+        this.labelsFilter = labelsFilter;
+    }
+
+    @Override
+    public void handle(T input, boolean allowTokens) throws IOException {
+        status.update();
+        Label label = labelsFilter.getLabelFor(input);
+        if (!labelWriters.containsKey(label)) {
+            createWriterFor(label);
+        }
+        if(graphClient != null) {
+            graphClient.updateStats(label);
+        }
+        labelWriters.get(label).handle(input, allowTokens);
+    }
+
+    @Override
+    public void close() {
+        try {
+            labelWriters.close();
+        } catch (Exception e) {
+            logger.warn("Error closing label writer: {}.", e.getMessage());
+        }
+    }
+
+    private void createWriterFor(Label label) {
+        try {
+            LabelSchema labelSchema = graphElementSchemas.getSchemaFor(label);
+
+            PropertyGraphPrinter propertyGraphPrinter = writerFactory.createPrinter(
+                    Directories.fileName(label.fullyQualifiedLabel(), index),
+                    labelSchema,
+                    targetConfig);
+            LabelWriter<T> labelWriter = writerFactory.createLabelWriter(propertyGraphPrinter, labelSchema.label());
+
+            labelWriters.put(label, labelWriter);
+            fileSpecificLabelSchemas.add(labelWriter.outputId(), targetConfig.format(), labelSchema);
+
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphJob.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.neptune.io.StatusOutputFormat;
 import com.amazonaws.services.neptune.propertygraph.GremlinFilters;
 import com.amazonaws.services.neptune.propertygraph.RangeConfig;
 import com.amazonaws.services.neptune.propertygraph.RangeFactory;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.*;
 import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
@@ -110,7 +111,7 @@ public class ExportPropertyGraphJob {
                 ExecutorService taskExecutor = Executors.newFixedThreadPool(rangeFactory.concurrency());
 
                 for (int index = 1; index <= rangeFactory.concurrency(); index++) {
-                    ExportPropertyGraphTask<?> exportTask = labelSpecificExportSpecification.createExportTask(
+                    ExportPropertyGraphTask exportTask = labelSpecificExportSpecification.createExportTask(
                             graphSchema,
                             g,
                             targetConfig,

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/ExportPropertyGraphTask.java
@@ -12,39 +12,37 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.propertygraph.io;
 
-import com.amazonaws.services.neptune.io.Directories;
 import com.amazonaws.services.neptune.io.Status;
 import com.amazonaws.services.neptune.propertygraph.*;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.FileSpecificLabelSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
-import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<FileSpecificLabelSchemas> {
+public class ExportPropertyGraphTask implements Callable<FileSpecificLabelSchemas> {
 
     private static final Logger logger = LoggerFactory.getLogger(ExportPropertyGraphTask.class);
 
     private final GraphElementSchemas graphElementSchemas;
     private final LabelsFilter labelsFilter;
-    private final GraphClient<T> graphClient;
-    private final WriterFactory<T> writerFactory;
+    private final GraphClient<? extends PGResult> graphClient;
+    private final WriterFactory<? extends PGResult> writerFactory;
     private final PropertyGraphTargetConfig targetConfig;
     private final RangeFactory rangeFactory;
     private final GremlinFilters gremlinFilters;
     private final Status status;
     private final AtomicInteger index;
-    private final LabelWriters<T> labelWriters;
+    private final LabelWriters<PGResult> labelWriters;
 
     public ExportPropertyGraphTask(GraphElementSchemas graphElementSchemas,
                                    LabelsFilter labelsFilter,
-                                   GraphClient<T> graphClient,
-                                   WriterFactory<T> writerFactory,
+                                   GraphClient<? extends PGResult> graphClient,
+                                   WriterFactory<? extends PGResult> writerFactory,
                                    PropertyGraphTargetConfig targetConfig,
                                    RangeFactory rangeFactory,
                                    GremlinFilters gremlinFilters,
@@ -70,7 +68,7 @@ public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<Fi
         FileSpecificLabelSchemas fileSpecificLabelSchemas = new FileSpecificLabelSchemas();
 
         CountingHandler handler = new CountingHandler(
-                new TaskHandler(
+                new ExportPGTaskHandler(
                         fileSpecificLabelSchemas,
                         graphElementSchemas,
                         targetConfig,
@@ -78,7 +76,8 @@ public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<Fi
                         labelWriters,
                         graphClient,
                         status,
-                        index
+                        index,
+                        labelsFilter
                 ));
 
         try {
@@ -104,96 +103,4 @@ public class ExportPropertyGraphTask<T extends Map<?, ?>> implements Callable<Fi
         return fileSpecificLabelSchemas;
     }
 
-    private class TaskHandler implements GraphElementHandler<T> {
-
-        private final FileSpecificLabelSchemas fileSpecificLabelSchemas;
-        private final GraphElementSchemas graphElementSchemas;
-        private final PropertyGraphTargetConfig targetConfig;
-        private final WriterFactory<T> writerFactory;
-        private final LabelWriters<T> labelWriters;
-        private final GraphClient<T> graphClient;
-        private final Status status;
-        private final AtomicInteger index;
-
-        private TaskHandler(FileSpecificLabelSchemas fileSpecificLabelSchemas,
-                            GraphElementSchemas graphElementSchemas,
-                            PropertyGraphTargetConfig targetConfig,
-                            WriterFactory<T> writerFactory,
-                            LabelWriters<T> labelWriters,
-                            GraphClient<T> graphClient,
-                            Status status,
-                            AtomicInteger index) {
-            this.fileSpecificLabelSchemas = fileSpecificLabelSchemas;
-            this.graphElementSchemas = graphElementSchemas;
-            this.targetConfig = targetConfig;
-            this.writerFactory = writerFactory;
-            this.labelWriters = labelWriters;
-            this.graphClient = graphClient;
-            this.status = status;
-            this.index = index;
-        }
-
-        @Override
-        public void handle(T input, boolean allowTokens) throws IOException {
-            status.update();
-            Label label = graphClient.getLabelFor(input, labelsFilter);
-            if (!labelWriters.containsKey(label)) {
-                createWriterFor(label);
-            }
-            graphClient.updateStats(label);
-            labelWriters.get(label).handle(input, allowTokens);
-        }
-
-        @Override
-        public void close() {
-            try {
-                labelWriters.close();
-            } catch (Exception e) {
-                logger.warn("Error closing label writer: {}.", e.getMessage());
-            }
-        }
-
-        private void createWriterFor(Label label) {
-            try {
-                LabelSchema labelSchema = graphElementSchemas.getSchemaFor(label);
-
-                PropertyGraphPrinter propertyGraphPrinter = writerFactory.createPrinter(
-                        Directories.fileName(label.fullyQualifiedLabel(), index),
-                        labelSchema,
-                        targetConfig);
-                LabelWriter<T> labelWriter = writerFactory.createLabelWriter(propertyGraphPrinter, labelSchema.label());
-
-                labelWriters.put(label, labelWriter);
-                fileSpecificLabelSchemas.add(labelWriter.outputId(), targetConfig.format(), labelSchema);
-
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-        }
-    }
-
-    private class CountingHandler implements GraphElementHandler<T> {
-
-        private final GraphElementHandler<T> parent;
-        private long counter = 0;
-
-        private CountingHandler(GraphElementHandler<T> parent) {
-            this.parent = parent;
-        }
-
-        @Override
-        public void handle(T input, boolean allowTokens) throws IOException {
-            parent.handle(input, allowTokens);
-            counter++;
-        }
-
-        long numberProcessed() {
-            return counter;
-        }
-
-        @Override
-        public void close() throws Exception {
-            parent.close();
-        }
-    }
 }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/LabelWriters.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/LabelWriters.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -20,7 +21,7 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
-public class LabelWriters<T extends Map<?, ?>> implements AutoCloseable {
+public class LabelWriters<T extends PGResult> implements AutoCloseable {
 
     private static final Logger logger = LoggerFactory.getLogger(LabelWriters.class);
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/NodeWriter.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/NodeWriter.java
@@ -13,13 +13,13 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 
-public class NodeWriter implements LabelWriter<Map<String, Object>> {
+public class NodeWriter implements LabelWriter<PGResult> {
 
     private final PropertyGraphPrinter propertyGraphPrinter;
 
@@ -27,15 +27,12 @@ public class NodeWriter implements LabelWriter<Map<String, Object>> {
         this.propertyGraphPrinter = propertyGraphPrinter;
     }
 
-
     @Override
-    public void handle(Map<String, Object> map, boolean allowTokens) throws IOException {
+    public void handle(PGResult node, boolean allowTokens) throws IOException {
 
-        @SuppressWarnings("unchecked")
-        Map<?, Object> properties = (Map<?, Object>) map.get("properties");
-        String id = String.valueOf(map.get("~id"));
-        @SuppressWarnings("unchecked")
-        List<String> labels = (List<String>) map.get("~label");
+        Map<?, Object> properties = node.getProperties();
+        String id = String.valueOf(node.getId());
+        List<String> labels = node.getLabel();
 
         labels = Label.fixLabelsIssue(labels);
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/NodesWriterFactory.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/NodesWriterFactory.java
@@ -13,12 +13,12 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
 
 import java.io.IOException;
-import java.util.Map;
 
-public class NodesWriterFactory implements WriterFactory<Map<String, Object>> {
+public class NodesWriterFactory implements WriterFactory<PGResult> {
 
     @Override
     public PropertyGraphPrinter createPrinter(String name, LabelSchema labelSchema, PropertyGraphTargetConfig targetConfig) throws IOException {
@@ -31,7 +31,7 @@ public class NodesWriterFactory implements WriterFactory<Map<String, Object>> {
     }
 
     @Override
-    public LabelWriter<Map<String, Object>> createLabelWriter(PropertyGraphPrinter propertyGraphPrinter, Label label) {
+    public LabelWriter<PGResult> createLabelWriter(PropertyGraphPrinter propertyGraphPrinter, Label label) {
         return new NodeWriter(propertyGraphPrinter);
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryJob.java
@@ -17,7 +17,6 @@ import com.amazonaws.services.neptune.io.StatusOutputFormat;
 import com.amazonaws.services.neptune.propertygraph.NamedQuery;
 import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
 import com.amazonaws.services.neptune.propertygraph.NeptuneGremlinClient;
-import com.amazonaws.services.neptune.util.Activity;
 import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryTask.java
@@ -17,6 +17,9 @@ import com.amazonaws.services.neptune.io.Status;
 import com.amazonaws.services.neptune.propertygraph.Label;
 import com.amazonaws.services.neptune.propertygraph.NamedQuery;
 import com.amazonaws.services.neptune.propertygraph.NeptuneGremlinClient;
+import com.amazonaws.services.neptune.propertygraph.NodeLabelStrategy;
+import com.amazonaws.services.neptune.propertygraph.io.result.QueriesNodeResult;
+import com.amazonaws.services.neptune.propertygraph.schema.FileSpecificLabelSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
 import com.amazonaws.services.neptune.util.Activity;
@@ -146,6 +149,10 @@ public class QueryTask implements Callable<Object> {
                         throw new RuntimeException(e);
                     }
                 });
+    }
+
+    private QueriesNodeResult getPGResult(Map<?, ?> map) {
+        return new QueriesNodeResult(map);
     }
 
     private HashMap<?, ?> castToMap(Object o) {

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/ExportPGNodeResult.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/ExportPGNodeResult.java
@@ -1,0 +1,54 @@
+package com.amazonaws.services.neptune.propertygraph.io.result;
+
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+
+import java.util.List;
+import java.util.Map;
+
+public class ExportPGNodeResult implements PGResult {
+    private final Map<String, Object> nodeMap;
+
+    public ExportPGNodeResult(Map<String, Object> input) {
+        nodeMap = input;
+    }
+
+    @Override
+    public GraphElementType getGraphElementType() {
+        return GraphElementType.nodes;
+    }
+
+    @Override
+    public List<String> getLabel() {
+        return (List<String>) nodeMap.get("~label");
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(nodeMap.get("~id"));
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return (Map<String, Object>) nodeMap.get("properties");
+    }
+
+    @Override
+    public String getFrom() {
+        throw new IllegalStateException("Illegal attempt to getFrom() from a Node Result");
+    }
+
+    @Override
+    public String getTo() {
+        throw new IllegalStateException("Illegal attempt to getTo() from a Node Result");
+    }
+
+    @Override
+    public List<String> getFromLabels() {
+        throw new IllegalStateException("Illegal attempt to getFromLabels() from a Node Result");
+    }
+
+    @Override
+    public List<String> getToLabels() {
+        throw new IllegalStateException("Illegal attempt to getToLabels() from a Node Result");
+    }
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/PGEdgeResult.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/PGEdgeResult.java
@@ -1,0 +1,57 @@
+package com.amazonaws.services.neptune.propertygraph.io.result;
+
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+public class PGEdgeResult implements PGResult{
+    private final Map<String, Object> edgeMap;
+
+    public PGEdgeResult(Map<String, Object> input) {
+        edgeMap = input;
+    }
+
+    @Override
+    public GraphElementType getGraphElementType() {
+        return GraphElementType.nodes;
+    }
+
+    @Override
+    public List<String> getLabel() {
+        List<String> labels = new ArrayList<>();
+        labels.add(String.valueOf(edgeMap.get("~label")));
+        return labels;
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(edgeMap.get("~id"));
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return (Map<String, Object>) edgeMap.get("properties");
+    }
+
+    @Override
+    public String getFrom() {
+        return String.valueOf(edgeMap.get("~from"));
+    }
+
+    @Override
+    public String getTo() {
+        return String.valueOf(edgeMap.get("~to"));
+    }
+
+    @Override
+    public List<String> getFromLabels() {
+        return (List<String>) edgeMap.get("~fromLabels");
+    }
+
+    @Override
+    public List<String> getToLabels() {
+        return (List<String>) edgeMap.get("~toLabels");
+    }
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/PGResult.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/PGResult.java
@@ -1,0 +1,17 @@
+package com.amazonaws.services.neptune.propertygraph.io.result;
+
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+
+import java.util.List;
+import java.util.Map;
+
+public interface PGResult {
+    public GraphElementType getGraphElementType();
+    public List<String> getLabel();
+    public String getId();
+    public Map<String, Object> getProperties();
+    public String getFrom();
+    public String getTo();
+    public List<String> getFromLabels();
+    public List<String> getToLabels();
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/QueriesNodeResult.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/result/QueriesNodeResult.java
@@ -1,0 +1,65 @@
+package com.amazonaws.services.neptune.propertygraph.io.result;
+
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+import org.apache.tinkerpop.gremlin.structure.T;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.ArrayList;
+
+public class QueriesNodeResult implements PGResult {
+    private final Map<?, ?> nodeMap;
+
+    private final Map<?, ?> properties;
+
+    public QueriesNodeResult(Map<?, ?> input) {
+        nodeMap = input;
+        properties = new HashMap<>(input);
+        properties.remove(T.label);
+        properties.remove(T.id);
+    }
+
+    @Override
+    public GraphElementType getGraphElementType() {
+        return GraphElementType.nodes;
+    }
+
+    public List<String> getLabel() {
+        List<String> labels = new ArrayList<>(1);
+        labels.add(String.valueOf(nodeMap.get(T.label)));
+        return labels;
+    }
+
+    @Override
+    public String getId() {
+        return String.valueOf(nodeMap.get(T.id));
+    }
+
+    @Override
+    public Map<String, Object> getProperties() {
+        return (Map<String, Object>) properties;
+    }
+
+    @Override
+    public String getFrom() {
+        throw new IllegalStateException("Illegal attempt to getFrom() from a Node Result");
+    }
+
+    @Override
+    public String getTo() {
+        throw new IllegalStateException("Illegal attempt to getTo() from a Node Result");
+    }
+
+    @Override
+    public List<String> getFromLabels() {
+        throw new IllegalStateException("Illegal attempt to getFromLabels() from a Node Result");
+    }
+
+    @Override
+    public List<String> getToLabels() {
+        throw new IllegalStateException("Illegal attempt to getToLabels() from a Node Result");
+    }
+
+}

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.neptune.propertygraph.*;
 import com.amazonaws.services.neptune.propertygraph.io.ExportPropertyGraphTask;
 import com.amazonaws.services.neptune.propertygraph.io.GraphElementHandler;
 import com.amazonaws.services.neptune.propertygraph.io.PropertyGraphTargetConfig;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
 import java.util.*;
@@ -55,7 +56,7 @@ public class ExportSpecification {
             return;
         }
 
-        GraphClient<Map<String, Object>> graphClient = graphElementType.graphClient(g, tokensOnly, stats, featureToggles);
+        GraphClient<? extends PGResult> graphClient = graphElementType.graphClient(g, tokensOnly, stats, featureToggles);
 
         graphClient.queryForSchema(
                 new CreateSchemaHandler(graphElementType, graphSchema),
@@ -69,7 +70,7 @@ public class ExportSpecification {
             return;
         }
 
-        GraphClient<Map<String, Object>> graphClient = graphElementType.graphClient(g, tokensOnly, stats, featureToggles);
+        GraphClient<? extends PGResult> graphClient = graphElementType.graphClient(g, tokensOnly, stats, featureToggles);
         Collection<Label> labels = labelsFilter.getLabelsUsing(graphClient);
 
         for (Label label : labels) {
@@ -95,7 +96,7 @@ public class ExportSpecification {
                 concurrencyConfig);
     }
 
-    public ExportPropertyGraphTask<Map<String, Object>> createExportTask(GraphSchema graphSchema,
+    public ExportPropertyGraphTask createExportTask(GraphSchema graphSchema,
                                                                          GraphTraversalSource g,
                                                                          PropertyGraphTargetConfig targetConfig,
                                                                          GremlinFilters gremlinFilters,
@@ -104,7 +105,7 @@ public class ExportSpecification {
                                                                          AtomicInteger index,
                                                                          AtomicInteger fileDescriptorCount,
                                                                          int maxFileDescriptorCount) {
-        return new ExportPropertyGraphTask<>(
+        return new ExportPropertyGraphTask(
                 graphSchema.copyOfGraphElementSchemasFor(graphElementType),
                 labelsFilter,
                 graphElementType.graphClient(g, tokensOnly, stats, featureToggles),

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementType.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementType.java
@@ -20,11 +20,11 @@ import com.amazonaws.services.neptune.propertygraph.NodesClient;
 import com.amazonaws.services.neptune.propertygraph.io.EdgesWriterFactory;
 import com.amazonaws.services.neptune.propertygraph.io.NodesWriterFactory;
 import com.amazonaws.services.neptune.propertygraph.io.WriterFactory;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 
 public enum GraphElementType {
 
@@ -35,12 +35,12 @@ public enum GraphElementType {
         }
 
         @Override
-        public GraphClient<Map<String, Object>> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles) {
+        public GraphClient<? extends PGResult> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles) {
             return new NodesClient(g, tokensOnly, stats, featureToggles);
         }
 
         @Override
-        public WriterFactory<Map<String, Object>> writerFactory() {
+        public WriterFactory<? extends PGResult> writerFactory() {
             return new NodesWriterFactory();
         }
     },
@@ -51,17 +51,17 @@ public enum GraphElementType {
         }
 
         @Override
-        public GraphClient<Map<String, Object>> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles) {
+        public GraphClient<? extends PGResult> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles) {
             return new EdgesClient(g, tokensOnly, stats, featureToggles);
         }
 
         @Override
-        public WriterFactory<Map<String, Object>> writerFactory() {
+        public WriterFactory<? extends PGResult> writerFactory() {
             return new EdgesWriterFactory();
         }
     };
 
     public abstract Collection<String> tokenNames();
-    public abstract GraphClient<Map<String, Object>> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles);
-    public abstract WriterFactory<Map<String, Object>> writerFactory();
+    public abstract GraphClient<? extends PGResult> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles);
+    public abstract WriterFactory<? extends PGResult> writerFactory();
 }

--- a/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
@@ -1,9 +1,14 @@
 package com.amazonaws.services.neptune;
 
 import com.amazonaws.services.neptune.export.NeptuneExportRunner;
+import com.amazonaws.services.neptune.propertygraph.io.JsonResource;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphSchema;
 import org.junit.Test;
 
 import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 
 import static org.junit.Assert.assertTrue;
 
@@ -23,6 +28,22 @@ public class ExportPgFromQueriesIntegrationTest extends AbstractExportIntegratio
         assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueries"), resultDir);
     }
 
+    @Test
+    public void testExportPgFromQueriesWithStructuredOutput() {
+        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
+                "-d", outputDir.getPath(),
+                "-q", "airport=g.V().hasLabel('airport').elementMap()",
+                "--include-type-definitions",
+                "--structured-output"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentStructuredOutput(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput"), resultDir);
+    }
+
     @Override
     protected void assertEquivalentResults(final File expected, final File actual) {
         assertTrue("queries.json does not match expected results", areJsonContentsEqual(expected.listFiles((dir, name) -> name.equals("queries.json"))[0], actual.listFiles((dir, name) -> name.equals("queries.json"))[0]));
@@ -30,6 +51,24 @@ public class ExportPgFromQueriesIntegrationTest extends AbstractExportIntegratio
             assertTrue(expectedResultsDir.isDirectory());
             String dirName = expectedResultsDir.getName();
             assertTrue("results/"+dirName+" directory does not match expected results", areLabelledDirContentsEquivalent(expectedResultsDir, new File(actual+"/results/"+dirName), dirName));
+        }
+    }
+
+    private void assertEquivalentStructuredOutput(final File expected, final File actual) {
+        GraphSchema config = null;
+        try {
+            config = new JsonResource<GraphSchema, Boolean>(
+                    "Config file",
+                    new URI(expected.getPath() + "/config.json"),
+                    GraphSchema.class).get();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+
+        if (expected.listFiles(((dir, name) -> name.equals("nodes"))).length >= 1) {
+            assertTrue("nodes directory does not match expected results", areDirContentsEquivalent(expected + "/nodes", actual + "/nodes", config));
         }
     }
 

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/AllLabelsTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/AllLabelsTest.java
@@ -1,0 +1,100 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.io.result.ExportPGNodeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.structure.Element;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+public class AllLabelsTest {
+
+    @Test
+    public void shouldGetLabelForPGResult() {
+        LabelStrategy labelStrategy = NodeLabelStrategy.nodeLabelsOnly;
+        AllLabels allLabels = new AllLabels(labelStrategy);
+
+        Map<String, Object> input = new HashMap<>();
+        List<String> labels = new ArrayList<>();
+        labels.add("TestLabel");
+        input.put("~label", labels);
+        PGResult pgResult = new ExportPGNodeResult(input);
+
+        Label label = allLabels.getLabelFor(pgResult);
+
+        assertEquals(new Label(labels), label);
+    }
+
+    @Test
+    public void shouldGetLabelForInputMap() {
+        LabelStrategy labelStrategy = NodeLabelStrategy.nodeLabelsOnly;
+        AllLabels allLabels = new AllLabels(labelStrategy);
+
+        Map<String, Object> input = new HashMap<>();
+        List<String> labels = new ArrayList<>();
+        labels.add("TestLabel");
+        input.put("~label", labels);
+
+        Label label = allLabels.getLabelFor(input);
+
+        assertEquals(new Label(labels), label);
+    }
+
+    @Test
+    public void shouldNotAddAnyLabelFiltersWhenApplied() {
+        AllLabels allLabels = new AllLabels(NodeLabelStrategy.nodeLabelsOnly);
+
+        AnonymousTraversalSource<GraphTraversalSource> traversalSource = AnonymousTraversalSource.traversal();
+        GraphTraversalSource g = traversalSource.withGraph(EmptyGraph.instance());
+
+        GraphTraversal<? extends Element, ?> traversal =
+                allLabels.apply(g.V(), new FeatureToggles(Collections.emptyList()), GraphElementType.nodes);
+
+        assertEquals("__.V()",
+                GremlinQueryDebugger.queryAsString(traversal));
+    }
+
+    @Test
+    public void shouldNotAddAnyLabelFiltersWhenAppliedForEdges() {
+        AllLabels allLabels = new AllLabels(EdgeLabelStrategy.edgeLabelsOnly);
+
+        AnonymousTraversalSource<GraphTraversalSource> traversalSource = AnonymousTraversalSource.traversal();
+        GraphTraversalSource g = traversalSource.withGraph(EmptyGraph.instance());
+
+        GraphTraversal<? extends Element, ?> traversal =
+                allLabels.apply(g.E(), new FeatureToggles(Collections.emptyList()), GraphElementType.nodes);
+
+        assertEquals("__.E()",
+                GremlinQueryDebugger.queryAsString(traversal));
+    }
+
+    @Test
+    public void getPropertiesForLabelsTest() {
+        AllLabels allLabels = new AllLabels(NodeLabelStrategy.nodeLabelsOnly);
+
+        GraphElementSchemas graphElementSchemas = new GraphElementSchemas();
+        Label label = new Label("test");
+        Map<String, Object> properties = new HashMap<>();
+        properties.put("Test Prop int", 1);
+        properties.put("Test Prop String", "String");
+        properties.put("Test Prop Array", new int[]{1, 2});
+
+        graphElementSchemas.update(label, properties, false);
+
+        String[] propertyLabels = allLabels.getPropertiesForLabels(graphElementSchemas);
+        assertEquals(new String[]{"Test Prop String", "Test Prop Array", "Test Prop int"}, propertyLabels);
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/EdgeLabelStrategyTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/EdgeLabelStrategyTest.java
@@ -1,0 +1,90 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy.edgeLabelsOnly;
+import static com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy.edgeAndVertexLabels;
+import static org.junit.Assert.assertEquals;
+
+public class EdgeLabelStrategyTest {
+
+    private final GraphTraversalSource gmodern;
+    private final Map<String, Object> inputMap;
+    private final PGEdgeResult pgEdgeResult;
+    private final List<String> fromLabels;
+    private final List<String> toLabels;
+
+    public EdgeLabelStrategyTest() {
+        gmodern = TinkerFactory.createModern().traversal();
+
+        inputMap = new HashMap<>();
+        inputMap.put("~label", "TestLabel");
+        inputMap.put("~from", "FromID");
+        inputMap.put("~to", "ToID");
+        fromLabels = new ArrayList<>();
+        toLabels = new ArrayList<>();
+        fromLabels.add("FromLabel");
+        toLabels.add("ToLabels");
+        inputMap.put("~fromLabels", fromLabels);
+        inputMap.put("~toLabels", toLabels);
+
+        pgEdgeResult = new PGEdgeResult(inputMap);
+    }
+
+    //Edge Labels Only
+
+    @Test
+    public void shouldGetEdgeLabelsFromModernGraph() {
+        Collection<Label> labels = edgeLabelsOnly.getLabels(gmodern);
+
+        Collection<Label> expected = new HashSet<>();
+        expected.add(new Label("knows"));
+        expected.add(new Label("created"));
+
+        assertEquals(expected, labels);
+    }
+
+    @Test
+    public void shouldGetEdgeLabelForMap() {
+        assertEquals(new Label("TestLabel"), edgeLabelsOnly.getLabelFor(inputMap));
+    }
+
+    @Test
+    public void shouldGetEdgeLabelForPgEdgeResult() {
+        assertEquals(new Label("TestLabel"), edgeLabelsOnly.getLabelFor(pgEdgeResult));
+    }
+
+    // Edge and Vertex Labels
+
+    @Test
+    public void shouldGetEdgeAndVertexLabelsFromModernGraph() {
+        Collection<Label> labels = edgeAndVertexLabels.getLabels(gmodern);
+
+        Collection<Label> expected = new HashSet<>();
+        expected.add(new Label("(person)-knows-(person)"));
+        expected.add(new Label("(person)-created-(software)"));
+
+        assertEquals(expected, labels);
+    }
+
+    @Test
+    public void shouldGetEdgeAndVertexLabelForMap() {
+        assertEquals(new Label("TestLabel", fromLabels, toLabels), edgeAndVertexLabels.getLabelFor(inputMap));
+    }
+
+    @Test
+    public void shouldGetEdgeAndVertexLabelForPgEdgeResult() {
+        assertEquals(new Label("TestLabel", fromLabels, toLabels), edgeAndVertexLabels.getLabelFor(pgEdgeResult));
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/EdgesClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/EdgesClientTest.java
@@ -2,6 +2,8 @@ package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.propertygraph.io.GraphElementHandler;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphSchema;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -14,9 +16,13 @@ import org.junit.Test;
 import org.mockito.Mockito;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -49,7 +55,7 @@ public class EdgesClientTest {
                     @Override
                     public void close() {}
                 },
-                Range.ALL, new AllLabels(mock(LabelStrategy.class)), GremlinFilters.EMPTY);
+                Range.ALL, new AllLabels(EdgeLabelStrategy.edgeLabelsOnly), GremlinFilters.EMPTY);
 
         JsonNode expectedSchema = new ObjectMapper().readTree(
                 "{\n" +
@@ -75,6 +81,24 @@ public class EdgesClientTest {
                         "}"
         );
         assertEquals(expectedSchema, schema.toJson(false));
+    }
+
+    @Test
+    public void testQueryForValues() {
+        List<String> ids = new ArrayList<>();
+        GraphElementHandler<PGResult> handler = new GraphElementHandler<PGResult>() {
+            @Override
+            public void handle(PGResult element, boolean allowTokens) throws IOException {
+                ids.add(element.getId());
+                assertFalse(allowTokens);
+            }
+            @Override
+            public void close() throws Exception {}
+        };
+        client.queryForValues(handler, Range.ALL, new AllLabels(EdgeLabelStrategy.edgeLabelsOnly),
+                GremlinFilters.EMPTY, new GraphElementSchemas());
+
+        assertEquals(Arrays.asList("7","8","9","10","11","12"), ids);
     }
 
 }

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/NodeLabelStrategyTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/NodeLabelStrategyTest.java
@@ -1,0 +1,63 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import com.amazonaws.services.neptune.propertygraph.io.result.ExportPGNodeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+import static com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy.edgeAndVertexLabels;
+import static com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy.edgeLabelsOnly;
+import static com.amazonaws.services.neptune.propertygraph.NodeLabelStrategy.nodeLabelsOnly;
+import static org.junit.Assert.assertEquals;
+
+public class NodeLabelStrategyTest {
+
+    private final GraphTraversalSource gmodern;
+    private final Map<String, Object> inputMap;
+    private final PGResult pgNodeResult;
+    private final List<String> labels;
+
+    public NodeLabelStrategyTest() {
+        gmodern = TinkerFactory.createModern().traversal();
+
+        labels = new ArrayList<>();
+        labels.add("TestLabel");
+
+        inputMap = new HashMap<>();
+        inputMap.put("~label", labels);
+
+        pgNodeResult = new ExportPGNodeResult(inputMap);
+    }
+
+    //Node Labels Only
+
+    @Test
+    public void shouldGetLabelsFromModernGraph() {
+        Collection<Label> labels = nodeLabelsOnly.getLabels(gmodern);
+
+        Collection<Label> expected = new HashSet<>();
+        expected.add(new Label("person"));
+        expected.add(new Label("software"));
+
+        assertEquals(expected, labels);
+    }
+
+    @Test
+    public void shouldGetLabelForMap() {
+        assertEquals(new Label(labels), nodeLabelsOnly.getLabelFor(inputMap));
+    }
+
+    @Test
+    public void shouldGetLabelForPgEdgeResult() {
+        assertEquals(new Label(labels), nodeLabelsOnly.getLabelFor(pgNodeResult));
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/RangeFactoryTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/RangeFactoryTest.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.util.NotImplementedException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
@@ -37,6 +38,11 @@ public class RangeFactoryTest {
 
         @Override
         public Label getLabelFor(Map<String, Object> input) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public Label getLabelFor(PGResult input) {
             throw new NotImplementedException();
         }
 

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/SpecifiedLabelsTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/SpecifiedLabelsTest.java
@@ -13,6 +13,8 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph;
 
 import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.io.result.ExportPGNodeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
 import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
 import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
@@ -21,9 +23,12 @@ import org.apache.tinkerpop.gremlin.structure.Element;
 import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.junit.Assert.*;
 
@@ -216,5 +221,35 @@ public class SpecifiedLabelsTest {
         assertEquals("edges with zero labels", newFilter.description("edges"));
     }
 
+    @Test
+    public void shouldGetSpecifiedLabelForPGResult() {
+        LabelStrategy labelStrategy = NodeLabelStrategy.nodeLabelsOnly;
+        SpecifiedLabels specifiedLabels = new SpecifiedLabels(
+                Arrays.asList(new Label("label1"), new Label("label2")), labelStrategy);
+
+        Map<String, Object> input = new HashMap<>();
+        List<String> labels = Collections.singletonList("label1");
+        input.put("~label", labels);
+        PGResult pgResult = new ExportPGNodeResult(input);
+
+        Label label = specifiedLabels.getLabelFor(pgResult);
+
+        assertEquals(new Label(labels), label);
+    }
+
+    @Test
+    public void shouldGetSpecifiedLabelForInputMap() {
+        LabelStrategy labelStrategy = NodeLabelStrategy.nodeLabelsOnly;
+        SpecifiedLabels specifiedLabels = new SpecifiedLabels(
+                Arrays.asList(new Label("label1"), new Label("label2")), labelStrategy);
+
+        Map<String, Object> input = new HashMap<>();
+        List<String> labels = Collections.singletonList("label1");
+        input.put("~label", labels);
+
+        Label label = specifiedLabels.getLabelFor(input);
+
+        assertEquals(new Label(labels), label);
+    }
 
 }

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/EdgeWriterTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/EdgeWriterTest.java
@@ -1,0 +1,70 @@
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.AllLabels;
+import com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy;
+import com.amazonaws.services.neptune.propertygraph.EdgesClient;
+import com.amazonaws.services.neptune.propertygraph.ExportStats;
+import com.amazonaws.services.neptune.propertygraph.GremlinFilters;
+import com.amazonaws.services.neptune.propertygraph.Range;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class EdgeWriterTest {
+
+    private EdgesClient client;
+
+    @Before
+    public void setup() {
+        GraphTraversalSource graphTraversalSource = TinkerFactory.createModern().traversal();
+        ExportStats mockStats = mock(ExportStats.class);
+        FeatureToggles mockFeatures = mock(FeatureToggles.class);
+        when(mockFeatures.containsFeature(Mockito.any())).thenReturn(false);
+
+        client = new EdgesClient(graphTraversalSource, false, mockStats, mockFeatures);
+    }
+
+    @Test
+    public void testHandle() throws IOException {
+        PGEdgeResult edgeResult = getPGEdgeResult("7");
+        PropertyGraphStringPrinter pgPrinter = new PropertyGraphStringPrinter();
+        EdgeWriter edgeWriter = new EdgeWriter(pgPrinter, EdgeLabelStrategy.edgeLabelsOnly.getLabelFor(edgeResult));
+
+        edgeWriter.handle(edgeResult, true);
+
+        String expected = "Start Row\n" +
+                "Edge[7, knows, 1, 2] Properties{weight:0.5, } \n";
+
+        assertEquals(expected, pgPrinter.getOutput());
+    }
+
+    private PGEdgeResult getPGEdgeResult(String id) {
+        final PGEdgeResult[] result = {null};
+        GraphElementHandler<PGResult> handler = new GraphElementHandler<PGResult>() {
+            @Override
+            public void handle(PGResult element, boolean allowTokens) throws IOException {
+                if(element.getId().equals(id)) {
+                    result[0] = (PGEdgeResult) element;
+                }
+            }
+            @Override
+            public void close() throws Exception {}
+        };
+        client.queryForValues(handler, Range.ALL, new AllLabels(EdgeLabelStrategy.edgeLabelsOnly),
+                GremlinFilters.EMPTY, new GraphElementSchemas());
+        return result[0];
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/NodeWriterTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/NodeWriterTest.java
@@ -1,0 +1,72 @@
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.propertygraph.AllLabels;
+import com.amazonaws.services.neptune.propertygraph.EdgeLabelStrategy;
+import com.amazonaws.services.neptune.propertygraph.EdgesClient;
+import com.amazonaws.services.neptune.propertygraph.ExportStats;
+import com.amazonaws.services.neptune.propertygraph.GremlinFilters;
+import com.amazonaws.services.neptune.propertygraph.NodeLabelStrategy;
+import com.amazonaws.services.neptune.propertygraph.NodesClient;
+import com.amazonaws.services.neptune.propertygraph.Range;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGEdgeResult;
+import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementSchemas;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
+import org.apache.tinkerpop.gremlin.tinkergraph.structure.TinkerFactory;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class NodeWriterTest {
+
+    private NodesClient client;
+
+    @Before
+    public void setup() {
+        GraphTraversalSource graphTraversalSource = TinkerFactory.createModern().traversal();
+        ExportStats mockStats = mock(ExportStats.class);
+        FeatureToggles mockFeatures = mock(FeatureToggles.class);
+        when(mockFeatures.containsFeature(Mockito.any())).thenReturn(false);
+
+        client = new NodesClient(graphTraversalSource, false, mockStats, mockFeatures);
+    }
+
+    @Test
+    public void testHandle() throws IOException {
+        PGResult nodeResult = getPGNodeResult("1");
+        PropertyGraphStringPrinter pgPrinter = new PropertyGraphStringPrinter();
+        NodeWriter nodeWriter = new NodeWriter(pgPrinter);
+
+        nodeWriter.handle(nodeResult, true);
+
+        String expected = "Start Row\n" +
+                "Node[1, Labels{person, }] Properties{name:[marko], age:[29], } \n";
+
+        assertEquals(expected, pgPrinter.getOutput());
+    }
+
+    private PGResult getPGNodeResult(String id) {
+        final PGResult[] result = {null};
+        GraphElementHandler<PGResult> handler = new GraphElementHandler<PGResult>() {
+            @Override
+            public void handle(PGResult element, boolean allowTokens) throws IOException {
+                if(element.getId().equals(id)) {
+                    result[0] = element;
+                }
+            }
+            @Override
+            public void close() throws Exception {}
+        };
+        client.queryForValues(handler, Range.ALL, new AllLabels(NodeLabelStrategy.nodeLabelsOnly),
+                GremlinFilters.EMPTY, new GraphElementSchemas());
+        return result[0];
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphStringPrinter.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/PropertyGraphStringPrinter.java
@@ -1,0 +1,98 @@
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.propertygraph.schema.PropertySchema;
+import com.amazonaws.services.neptune.util.NotImplementedException;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+class PropertyGraphStringPrinter implements PropertyGraphPrinter {
+
+    StringBuilder output = new StringBuilder();
+
+    public String getOutput() {
+        return output.toString();
+    }
+
+    @Override
+    public String outputId() {
+        return null;
+    }
+
+    @Override
+    public void printHeaderMandatoryColumns(String... columns) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void printHeaderRemainingColumns(Collection<PropertySchema> remainingColumns) {
+        throw new NotImplementedException();
+    }
+
+    @Override
+    public void printProperties(Map<?, ?> properties) throws IOException {
+        output.append("Properties{");
+        properties.forEach((key, value) -> {
+            output.append(key.toString() + ":" + value.toString() + ", ");
+        });
+        output.append("} ");
+    }
+
+    @Override
+    public void printProperties(Map<?, ?> properties, boolean applyFormatting) throws IOException {
+        printProperties(properties);
+    }
+
+    @Override
+    public void printProperties(String id, String streamOperation, Map<?, ?> properties) throws IOException {
+        printProperties(properties);
+    }
+
+    @Override
+    public void printEdge(String id, String label, String from, String to) throws IOException {
+        output.append(String.format("Edge[%s, %s, %s, %s] ", id, label, from, to));
+    }
+
+    @Override
+    public void printEdge(String id, String label, String from, String to, Collection<String> fromLabels, Collection<String> toLabels) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("Edge[%s, %s, %s, %s, fromLabels{", id, label, from, to));
+        for (String fromLabel : fromLabels) {
+            builder.append(fromLabel).append(", ");
+        }
+        builder.append("}, toLabels{");
+        for (String toLabel : toLabels) {
+            builder.append(toLabel).append(", ");
+        }
+        builder.append("}] ");
+        output.append(builder.toString());
+    }
+
+    @Override
+    public void printNode(String id, List<String> labels) throws IOException {
+        StringBuilder builder = new StringBuilder();
+        builder.append(String.format("Node[%s, Labels{", id));
+        for (String label : labels) {
+            builder.append(label).append(", ");
+        }
+        builder.append("}] ");
+        output.append(builder.toString());
+    }
+
+    @Override
+    public void printStartRow() throws IOException {
+        output.append("Start Row\n");
+    }
+
+    @Override
+    public void printEndRow() throws IOException {
+        output.append("\n");
+    }
+
+    @Override
+    public void close() throws Exception {
+
+    }
+}

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/config.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/config.json
@@ -1,0 +1,88 @@
+{
+  "edges" : [ {
+    "label" : "route",
+    "properties" : [ {
+      "property" : "dist",
+      "dataType" : "Integer",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Integer" ]
+    } ]
+  } ],
+  "nodes" : [ {
+    "label" : "airport",
+    "properties" : [ {
+      "property" : "country",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "code",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "longest",
+      "dataType" : "Integer",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Integer" ]
+    }, {
+      "property" : "city",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "elev",
+      "dataType" : "Integer",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Integer" ]
+    }, {
+      "property" : "icao",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "lon",
+      "dataType" : "Double",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Double" ]
+    }, {
+      "property" : "type",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "region",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    }, {
+      "property" : "runways",
+      "dataType" : "Integer",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Integer" ]
+    }, {
+      "property" : "lat",
+      "dataType" : "Double",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "Double" ]
+    }, {
+      "property" : "desc",
+      "dataType" : "String",
+      "isMultiValue" : false,
+      "isNullable" : false,
+      "allTypes" : [ "String" ]
+    } ]
+  } ]
+}

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/nodes/airport-2.modified.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/nodes/airport-2.modified.csv
@@ -1,0 +1,47 @@
+~id,~label,country:string,code:string,longest:int,city:string,lon:double,type:string,elev:int,icao:string,region:string,runways:int,lat:double,desc:string
+1,airport,US,ATL,12390,Atlanta,-84.4281005859375,airport,1026,KATL,US-GA,5,33.6366996765137,Hartsfield - Jackson Atlanta International Airport
+2,airport,US,ANC,12400,Anchorage,-149.996002197266,airport,151,PANC,US-AK,3,61.1744003295898,Anchorage Ted Stevens
+3,airport,US,AUS,12250,Austin,-97.6698989868164,airport,542,KAUS,US-TX,2,30.1944999694824,Austin Bergstrom International Airport
+4,airport,US,BNA,11030,Nashville,-86.6781997680664,airport,599,KBNA,US-TN,4,36.1245002746582,Nashville International Airport
+5,airport,US,BOS,10083,Boston,-71.00520325,airport,19,KBOS,US-MA,6,42.36429977,Boston Logan
+6,airport,US,BWI,10502,Baltimore,-76.66829681,airport,143,KBWI,US-MD,3,39.17539978,Baltimore/Washington International Airport
+7,airport,US,DCA,7169,Washington D.C.,-77.0376968383789,airport,14,KDCA,US-DC,3,38.8521003723145,Ronald Reagan Washington National Airport
+8,airport,US,DFW,13401,Dallas,-97.0380020141602,airport,607,KDFW,US-TX,7,32.896800994873,Dallas/Fort Worth International Airport
+9,airport,US,FLL,9000,Fort Lauderdale,-80.152702331543,airport,64,KFLL,US-FL,2,26.0725994110107,Fort Lauderdale/Hollywood International Airport
+10,airport,US,IAD,11500,Washington D.C.,-77.45580292,airport,313,KIAD,US-VA,4,38.94449997,Washington Dulles International Airport
+11,airport,US,IAH,12001,Houston,-95.3414001464844,airport,96,KIAH,US-TX,5,29.9843997955322,George Bush Intercontinental
+12,airport,US,JFK,14511,New York,-73.77890015,airport,12,KJFK,US-NY,4,40.63980103,New York John F. Kennedy International Airport
+13,airport,US,LAX,12091,Los Angeles,-118.4079971,airport,127,KLAX,US-CA,4,33.94250107,Los Angeles International Airport
+14,airport,US,LGA,7003,New York,-73.87259674,airport,20,KLGA,US-NY,2,40.77719879,New York La Guardia
+15,airport,US,MCO,12005,Orlando,-81.3089981079102,airport,96,KMCO,US-FL,4,28.4293994903564,Orlando International Airport
+16,airport,US,MIA,13016,Miami,-80.2906036376953,airport,8,KMIA,US-FL,4,25.7931995391846,Miami International Airport
+17,airport,US,MSP,11006,Minneapolis,-93.2218017578,airport,841,KMSP,US-MN,4,44.8819999695,Minneapolis-St.Paul International Airport
+18,airport,US,ORD,13000,Chicago,-87.90480042,airport,672,KORD,US-IL,8,41.97859955,Chicago O'Hare International Airport
+19,airport,US,PBI,10000,West Palm Beach,-80.0955963134766,airport,19,KPBI,US-FL,3,26.6832008361816,Palm Beach International Airport
+20,airport,US,PHX,11489,Phoenix,-112.012001037598,airport,1135,KPHX,US-AZ,3,33.4342994689941,Phoenix Sky Harbor International Airport
+21,airport,US,RDU,10000,Raleigh,-78.7874984741211,airport,435,KRDU,US-NC,3,35.8776016235352,Raleigh-Durham
+22,airport,US,SEA,11901,Seattle,-122.30899810791,airport,432,KSEA,US-WA,3,47.4490013122559,Seattle-Tacoma
+23,airport,US,SFO,11870,San Francisco,-122.375,airport,13,KSFO,US-CA,4,37.6189994812012,San Francisco International Airport
+24,airport,US,SJC,11000,San Jose,-121.929000854492,airport,62,KSJC,US-CA,3,37.3625984191895,Norman Y. Mineta San Jose International Airport
+25,airport,US,TPA,11002,Tampa,-82.533203125,airport,26,KTPA,US-FL,3,27.9755001068115,Tampa International Airport
+26,airport,US,SAN,9400,San Diego,-117.190002441,airport,16,KSAN,US-CA,1,32.7336006165,San Diego Lindbergh
+27,airport,US,LGB,10003,Long Beach,-118.1520004,airport,60,KLGB,US-CA,3,33.81769943,Long Beach Airport
+28,airport,US,SNA,5701,Santa Ana,-117.8679962,airport,56,KSNA,US-CA,2,33.67570114,"Orange County/Santa Ana, John Wayne"
+29,airport,US,SLC,12002,Salt Lake City,-111.977996826172,airport,56,KSLC,US-UT,4,40.7883987426758,Salt Lake City
+30,airport,US,LAS,14512,Las Vegas,-115.1520004,airport,2181,KLAS,US-NV,4,36.08010101,Las Vegas Mc Carran
+31,airport,US,DEN,16000,Denver,-104.672996520996,airport,5433,KDEN,US-CO,6,39.8616981506348,Denver International Airport
+32,airport,US,HPN,6549,White Plains,-73.7076034545898,airport,439,KHPN,US-NY,2,41.0670013427734,Westchester County
+33,airport,US,SAT,8505,San Antonio,-98.4698028564453,airport,809,KSAT,US-TX,3,29.5337009429932,San Antonio
+34,airport,US,MSY,10104,New Orleans,-90.2580032348633,airport,3,KMSY,US-LA,2,29.9934005737305,New Orleans L. Armstrong
+35,airport,US,EWR,11000,Newark,-74.168701171875,airport,17,KEWR,US-NY,3,40.6925010681152,"Newark, Liberty"
+36,airport,US,CID,8600,Cedar Rapids,-91.7108001708984,airport,869,KCID,US-IA,2,41.8847007751465,The Eastern Iowa Airport
+37,airport,US,HNL,12312,Honolulu,-157.921997070312,airport,13,PHNL,US-HI,4,21.3187007904053,Honolulu International Airport
+38,airport,US,HOU,7602,Houston,-95.27890015,airport,46,KHOU,US-TX,4,29.64539909,Houston Hobby
+39,airport,US,ELP,12020,El Paso,-106.3779984,airport,3961,KELP,US-TX,3,31.80719948,El Paso International Airport
+40,airport,PR,SJU,10400,San Juan,-66.0018005371,airport,9,TJSJ,PR-U-A,2,18.4393997192,"Puerto Rico, Luis Munoz International Airport"
+41,airport,US,CLE,9956,Cleveland,-81.8498001099,airport,799,KCLE,US-OH,3,41.4117012024,"Cleveland, Hopkins International Airport"
+42,airport,US,OAK,10520,Oakland,-122.221000671387,airport,9,KOAK,US-CA,4,37.7212982177734,Oakland
+43,airport,US,TUS,10996,Tucson,-110.94100189209,airport,2643,KTUS,US-AZ,3,32.1161003112793,Tucson International Airport
+44,airport,US,SAF,8366,Santa Fe,-106.088996887,airport,6348,KSAF,US-NM,3,35.617099762,Santa Fe
+45,airport,US,PHL,10506,Philadelphia,-75.241096496582,airport,36,KPHL,US-PA,4,39.871898651123,Philadelphia International Airport
+46,airport,US,DTW,12003,Detroit,-83.353401184082,airport,645,KDTW,US-MI,6,42.2123985290527,"Detroit Metropolitan, Wayne County"

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/nodes/version-1.modified.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/nodes/version-1.modified.csv
@@ -1,0 +1,4 @@
+~id,~label,type:string,code:string,desc:string
+"0","version","version","0.77","Version: 0.77 Generated: 2017-10-06 16:24:52 UTC
+Graph created by Kelvin R. Lawrence
+Please let me know of any errors you find in the graph."

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/stats.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesStructuredOutput/stats.json
@@ -1,0 +1,236 @@
+{
+  "stats" : {
+    "nodes" : 47,
+    "edges" : 1326,
+    "properties" : 1881,
+    "details" : {
+      "nodes" : [ {
+        "description" : "version",
+        "labels" : [ "version" ],
+        "count" : 1,
+        "properties" : [ {
+          "name" : "type",
+          "count" : 1,
+          "numberOfRecords" : 1,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 1
+            } ]
+          }
+        }, {
+          "name" : "code",
+          "count" : 1,
+          "numberOfRecords" : 1,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 1
+            } ]
+          }
+        }, {
+          "name" : "desc",
+          "count" : 1,
+          "numberOfRecords" : 1,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 1
+            } ]
+          }
+        } ]
+      }, {
+        "description" : "airport",
+        "labels" : [ "airport" ],
+        "count" : 46,
+        "properties" : [ {
+          "name" : "country",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "code",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "longest",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Integer",
+            "counts" : [ {
+              "Integer" : 46
+            } ]
+          }
+        }, {
+          "name" : "city",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "elev",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Integer",
+            "counts" : [ {
+              "Integer" : 46
+            } ]
+          }
+        }, {
+          "name" : "icao",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "lon",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Double",
+            "counts" : [ {
+              "Double" : 46
+            } ]
+          }
+        }, {
+          "name" : "type",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "region",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        }, {
+          "name" : "runways",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Integer",
+            "counts" : [ {
+              "Integer" : 46
+            } ]
+          }
+        }, {
+          "name" : "lat",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Double",
+            "counts" : [ {
+              "Double" : 46
+            } ]
+          }
+        }, {
+          "name" : "desc",
+          "count" : 46,
+          "numberOfRecords" : 46,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "String",
+            "counts" : [ {
+              "String" : 46
+            } ]
+          }
+        } ]
+      } ],
+      "edges" : [ {
+        "description" : "route",
+        "labels" : {
+          "edge" : [ "route" ]
+        },
+        "count" : 1326,
+        "properties" : [ {
+          "name" : "dist",
+          "count" : 1326,
+          "numberOfRecords" : 1326,
+          "minCardinality" : 1,
+          "maxCardinality" : 1,
+          "isNullable" : false,
+          "dataTypes" : {
+            "inferred" : "Integer",
+            "counts" : [ {
+              "Integer" : 1326
+            } ]
+          }
+        } ]
+      } ]
+    }
+  }
+}


### PR DESCRIPTION
Issue #, if available:

Description of changes:

I'm working on a set of changes to export-pg-from-queries to enable structured CSV output which matches the [Neptune bulk-loader specifications](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load-tutorial-format-gremlin.html). This PR contains the first phase of those improvements. It adds a --structured-output argument to export-pg-from-queries which triggers the structured CSV output. This option currently only works for outputting Nodes and adds a restriction that the query must end in an `elementMap()` step, or produce `Map` results with the same structure as `elementMap()`.

_Reminder: Add relevant entry to CHANGELOG.md_

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

