### PR TITLE
Add repository map link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![CI Status](https://github.com/aws/neptune-export/actions/workflows/maven_build_and_verify.yml/badge.svg)](https://github.com/aws/neptune-export/actions/workflows/maven_build_and_verify.yml)
 [![Code Coverage](https://codecov.io/gh/aws/neptune-export/branch/develop/graph/badge.svg)](https://codecov.io/gh/aws/neptune-export)
+[![Project Map](https://sourcespy.com/shield.svg)](https://sourcespy.com/github/awsneptuneexport/)
 
 Exports Amazon Neptune property graph data to CSV or JSON, or RDF graph data to Turtle.
 


### PR DESCRIPTION
Adding a link to the high-level diagrams including module, library dependency and others (https://sourcespy.com/github/awsneptuneexport/). Built directly from source and updated on schedule. Intended to simplify developer's introduction to the project.

In the spirit of transparency - I am the author of the diagrams. Hope contributors find it useful.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.