### PR TITLE
Removed RDF Prefix Detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes:
 
+- Resolves issue in which RDF outputs may contain unexpected and potentially faulty prefixes.
+
 ### New Features and Improvements:
 
 - Add --filter-edges-early option to property graph exports. This option forces gremlinFilters to apply before the range() step which breaks up concurrent traversals. This may lead to improved performance in cases where the gremlinFilters are efficient and filter out the majority of edges.

--- a/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
+++ b/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
@@ -71,7 +71,7 @@ public class ExportRdfGraph extends NeptuneExportCommand implements Runnable {
                     GetLastEventIdStrategy getLastEventIdStrategy = streams.lastEventIdStrategy(cluster, eventIdFileResource);
                     getLastEventIdStrategy.saveLastEventId("sparql");
 
-                    try (NeptuneSparqlClient client = NeptuneSparqlClient.create(cluster.connectionConfig())) {
+                    try (NeptuneSparqlClient client = NeptuneSparqlClient.create(cluster.connectionConfig(), featureToggles())) {
 
                         ExportRdfJob job = exportScope.createJob(client, target.config(directories));
                         job.execute();

--- a/src/main/java/com/amazonaws/services/neptune/export/FeatureToggle.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/FeatureToggle.java
@@ -20,4 +20,5 @@ public enum FeatureToggle {
     Inject_Fault,
     Simulate_Cloned_Cluster,
     Keep_Rewritten_Files,
+    Infer_RDF_Prefixes,
 }

--- a/src/main/java/com/amazonaws/services/neptune/rdf/io/RdfTargetConfig.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/io/RdfTargetConfig.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.rdf.io;
 
+import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.io.Directories;
 import com.amazonaws.services.neptune.io.KinesisConfig;
 import com.amazonaws.services.neptune.io.OutputWriter;
@@ -41,8 +42,8 @@ public class RdfTargetConfig {
                 kinesisConfig);
     }
 
-    public RDFWriter createRDFWriter(OutputWriter outputWriter) {
-        return format.createWriter(outputWriter, new Prefixes());
+    public RDFWriter createRDFWriter(OutputWriter outputWriter, FeatureToggles featureToggles) {
+        return format.createWriter(outputWriter, new Prefixes(featureToggles));
     }
 
     public RdfExportFormat format() {


### PR DESCRIPTION
Issue #, if available:

Description of changes:
The existing prefix detection code provides limited value and does not correctly infer prefixes in the general case. Disabling this system fixes issues in which output files may contain unexpected and occasionally faulty prefixes. The system can be re-enabled if desired by using the `Infer_RDF_Prefixes` feature toggle.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

