### PR TITLE
Change RDF4J to use SPARQL Results JSON for export-rdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes:
 
+- Resolves issue where certain special characters would cause RDF export jobs to fail.
+
 ### New Features and Improvements:
 
 ## Neptune Export v1.1.0 (Release Date: October 31, 2023):

--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,18 @@
         </dependency>
 
         <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-queryresultio-sparqljson</artifactId>
+            <version>${rdf4j.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
             <!-- Replaces jaxb-api from RDF4J due to licensing. Both libraries are contain the same code. -->
             <groupId>jakarta.xml.bind</groupId>
             <artifactId>jakarta.xml.bind-api</artifactId>

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -25,10 +25,12 @@ import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
 import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
 import org.eclipse.rdf4j.model.ValueFactory;
+import org.eclipse.rdf4j.query.resultio.TupleQueryResultFormat;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.base.AbstractRepository;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.eclipse.rdf4j.rio.ParserConfig;
+import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.helpers.BasicParserSettings;
 import org.joda.time.DateTime;
@@ -79,6 +81,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
             public SPARQLProtocolSession createSPARQLProtocolSession(String s, String s1) {
                 SPARQLProtocolSession session = sessionManager.createSPARQLProtocolSession(s, s1);
                 session.setParserConfig(PARSER_CONFIG);
+                session.setPreferredTupleQueryResultFormat(TupleQueryResultFormat.JSON);
 
                 return session;
             }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Change internal serialization format used for export-rdf to `sparql-results+json` instead of `sparql-results+xml`. The main motivation behind this is that XML imposes a greater restrictions on special characters which can lead to parsing failures.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

