### PR TITLE
Changed GSP accept header to n-triples

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -168,12 +168,11 @@ public class NeptuneSparqlClient implements AutoCloseable {
         } else {
             HttpClient httpClient = chooseRepository().getHttpClient();
             HttpUriRequest request = new HttpGet(getGSPEndpoint("default"));
-            request.addHeader("Accept", "application/n-quads");
 
             org.apache.http.HttpResponse response = httpClient.execute(request);
             InputStream responseBody = response.getEntity().getContent();
 
-            RDFParser rdfParser = Rio.createParser(RDFFormat.NQUADS);
+            RDFParser rdfParser = Rio.createParser(RDFFormat.NTRIPLES);
             OutputWriter outputWriter = targetConfig.createOutputWriter();
             RDFWriter writer = targetConfig.createRDFWriter(outputWriter, new FeatureToggles(Collections.emptyList()));
             rdfParser.setRDFHandler(writer);

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -168,6 +168,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
         } else {
             HttpClient httpClient = chooseRepository().getHttpClient();
             HttpUriRequest request = new HttpGet(getGSPEndpoint("default"));
+            request.addHeader("Accept", "application/n-triples");
 
             org.apache.http.HttpResponse response = httpClient.execute(request);
             InputStream responseBody = response.getEntity().getContent();


### PR DESCRIPTION
Issue #, if available:

Description of changes:

GSP GET requests will use ntriples by default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

