### PR TITLE
Update mutating step list in --gremlin-filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Bug Fixes:
 
+- Update `--gremlin-filters` to block use of mutating steps `mergeV()` and `mergeE()`
+
 ### New Features and Improvements:
 
 ## Neptune Export v1.1.3 (Release Date: November 30, 2023):

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
@@ -36,7 +36,7 @@ public class GremlinFilters {
     private final String gremlinEdgeFilter;
     private final boolean filterEdgesEarly;
 
-    private static final List<String> INVALID_OPERATORS = Arrays.asList("addV", "addE", "write", "drop", "sideEffect", "property");
+    private static final List<String> INVALID_OPERATORS = Arrays.asList("addV", "addE", "write", "drop", "sideEffect", "property", "mergeV", "mergeE");
 
     public GremlinFilters(String gremlinFilter, String gremlinNodeFilter, String gremlinEdgeFilter, boolean filterEdgesEarly) {
         this.gremlinFilter = gremlinFilter;


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Updates `--gremlin-filters` to block use of mutating steps `mergeV()` and `mergeE()`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

