### PR TITLE
Add named graph filter for RDF exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 ### New Features and Improvements:
 
-- Add --split-queries option to export-pg-from-queries. When invoked, `range()` steps will be injected in the beginning of queries, and they will be split according to the configured concurrency.
+- Add `--split-queries` option to `export-pg-from-queries`. When invoked, `range()` steps will be injected in the beginning of queries, and they will be split according to the configured concurrency.
+- Add `--named-graph` argument to `export-rdf`. This argument allows for a single named graph URI to be specified to limit the scope of the export.
 
 ## Neptune Export v1.1.3 (Release Date: November 30, 2023):
 

--- a/README.md
+++ b/README.md
@@ -183,7 +183,15 @@ Queries whose results contain very large rows can sometimes trigger a `Corrupted
 
 ## Exporting an RDF Graph
               
-At present _neptune-export_ supports exporting an RDF dataset to Turtle with a single-threaded long-running query.
+At present _neptune-export_ supports exporting an RDF dataset to Turtle, NQuads, and NTriples with a single-threaded long-running query.
+
+### Exporting Named Graphs
+
+The default scope for `export-rdf` is to export the entire dataset (union of all named graphs). Use the `--named-graph <NamedGraphURI>` argument to limit the scope to a single named graph. This can only be used with the default `graph` scope (`--rdf-export-scope graph`).
+
+### Exporting from User-Supplied SPARQL query
+
+To export the results from a SPARQL query, use the `--rdf-export-scope query` and `--sparql <SPARQL Query>` arguments.
 
 ## Security
   

--- a/docs/export-rdf.md
+++ b/docs/export-rdf.md
@@ -13,6 +13,7 @@
                     [ {-e | --endpoint} <endpoint>... ] [ --export-id <exportId> ]
                     [ --format <format> ] [ --include-last-event-id ]
                     [ --lb-port <loadBalancerPort> ] [ --log-level <log level> ]
+                    [ --named-graph <namedGraphURI> ]
                     [ --nlb-endpoint <networkLoadBalancerEndpoint> ]
                     [ {-o | --output} <output> ] [ {-p | --port} <port> ]
                     [ --partition-directories <partitionDirectories> ]
@@ -227,7 +228,14 @@
                     error
     
                 This option may occur a maximum of 1 times
-    
+
+
+            --named-graph <namedGraphURI>
+                Limit scope of export to a single named graph (optional).
+                Can only be used with `--rdf-export-scope graph`. 
+
+                This option may occur a maximum of 1 times
+
     
             --nlb-endpoint <networkLoadBalancerEndpoint>
                 Network load balancer endpoint (optional: use only if connecting to

--- a/pom.xml
+++ b/pom.xml
@@ -277,6 +277,20 @@
             <version>6.12</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-repository-sail</artifactId>
+            <version>${rdf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.rdf4j</groupId>
+            <artifactId>rdf4j-sail-memory</artifactId>
+            <version>${rdf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
@@ -19,9 +19,6 @@ import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.ArrayList;
-import java.util.List;
-
 public class RdfExportScopeModule {
 
     @Option(name = {"--rdf-export-scope"}, description = "Export scope (optional, default 'graph').")

--- a/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
@@ -19,6 +19,9 @@ import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import org.apache.commons.lang.StringUtils;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class RdfExportScopeModule {
 
     @Option(name = {"--rdf-export-scope"}, description = "Export scope (optional, default 'graph').")
@@ -30,12 +33,22 @@ public class RdfExportScopeModule {
     @Once
     private String query;
 
+    //TODO:: Add parsing for space separated lists
+    @Option(name = {"--named-graphs"}, description = "Named Graphs to be exported. Can only be used with `--rdf-export-scope graph`")
+    private List<String> namedGraphs = new ArrayList<>();
+
     public ExportRdfJob createJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig){
         if (scope == RdfExportScope.graph){
-            return new ExportRdfGraphJob(client, targetConfig);
+            return new ExportRdfGraphJob(client, targetConfig, namedGraphs);
         } else if (scope == RdfExportScope.edges){
+            if (!namedGraphs.isEmpty()){
+                throw new IllegalStateException("`--named-graphs` can only be used with `--rdf-export-scope graph`");
+            }
             return new ExportRdfEdgesJob(client, targetConfig);
         } else if (scope == RdfExportScope.query){
+            if (!namedGraphs.isEmpty()){
+                throw new IllegalStateException("`--named-graphs` can only be used with `--rdf-export-scope graph`");
+            }
             if (StringUtils.isEmpty(query)){
                 throw new IllegalStateException("You must supply a SPARQL query if exporting from a query");
             }

--- a/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
@@ -33,21 +33,21 @@ public class RdfExportScopeModule {
     @Once
     private String query;
 
-    //TODO:: Add parsing for space separated lists
-    @Option(name = {"--named-graphs"}, description = "Named Graphs to be exported. Can only be used with `--rdf-export-scope graph`")
-    private List<String> namedGraphs = new ArrayList<>();
+    @Option(name = {"--named-graph"}, description = "Named Graph to be exported. Can only be used with `--rdf-export-scope graph`")
+    @Once
+    private String namedGraph;
 
     public ExportRdfJob createJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig){
         if (scope == RdfExportScope.graph){
-            return new ExportRdfGraphJob(client, targetConfig, namedGraphs);
+            return new ExportRdfGraphJob(client, targetConfig, namedGraph);
         } else if (scope == RdfExportScope.edges){
-            if (!namedGraphs.isEmpty()){
-                throw new IllegalStateException("`--named-graphs` can only be used with `--rdf-export-scope graph`");
+            if (StringUtils.isNotEmpty(namedGraph)){
+                throw new IllegalStateException("`--named-graph` can only be used with `--rdf-export-scope graph`");
             }
             return new ExportRdfEdgesJob(client, targetConfig);
         } else if (scope == RdfExportScope.query){
-            if (!namedGraphs.isEmpty()){
-                throw new IllegalStateException("`--named-graphs` can only be used with `--rdf-export-scope graph`");
+            if (StringUtils.isNotEmpty(namedGraph)){
+                throw new IllegalStateException("`--named-graph` can only be used with `--rdf-export-scope graph`");
             }
             if (StringUtils.isEmpty(query)){
                 throw new IllegalStateException("You must supply a SPARQL query if exporting from a query");

--- a/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/RdfExportScopeModule.java
@@ -19,6 +19,8 @@ import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
 import com.github.rvesse.airline.annotations.restrictions.Once;
 import org.apache.commons.lang.StringUtils;
 
+import java.net.URL;
+
 public class RdfExportScopeModule {
 
     @Option(name = {"--rdf-export-scope"}, description = "Export scope (optional, default 'graph').")
@@ -36,6 +38,14 @@ public class RdfExportScopeModule {
 
     public ExportRdfJob createJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig){
         if (scope == RdfExportScope.graph){
+            if (StringUtils.isNotEmpty(namedGraph)) {
+                //Test that namedGraph is a valid URI
+                try {
+                    new URL(namedGraph).toURI();
+                } catch (Exception e) {
+                    throw new IllegalArgumentException("Invalid named-graph URI provided", e);
+                }
+            }
             return new ExportRdfGraphJob(client, targetConfig, namedGraph);
         } else if (scope == RdfExportScope.edges){
             if (StringUtils.isNotEmpty(namedGraph)){

--- a/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
@@ -15,6 +15,7 @@ package com.amazonaws.services.neptune.rdf;
 import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.Collections;
 import java.util.List;
@@ -23,16 +24,16 @@ public class ExportRdfGraphJob implements ExportRdfJob {
 
     private final NeptuneSparqlClient client;
     private final RdfTargetConfig targetConfig;
-    private final List<String> namedGraphs;
+    private final String namedGraph;
 
     public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig) {
-        this(client, targetConfig, Collections.emptyList());
+        this(client, targetConfig, null);
     }
 
-    public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig, List<String> namedGraphs) {
+    public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig, String namedGraph) {
         this.client = client;
         this.targetConfig = targetConfig;
-        this.namedGraphs = namedGraphs;
+        this.namedGraph = namedGraph;
     }
 
     @Override
@@ -40,12 +41,10 @@ public class ExportRdfGraphJob implements ExportRdfJob {
         Timer.timedActivity("exporting RDF as " + targetConfig.format().description(),
                 (CheckedActivity.Runnable) () -> {
                     System.err.println("Creating statement files");
-                    if(namedGraphs == null || namedGraphs.isEmpty()) {
+                    if(StringUtils.isEmpty(namedGraph)) {
                         client.executeCompleteExport(targetConfig);
                     } else {
-                        for(String namedGraph : namedGraphs) {
-                            client.executeNamedGraphExport(targetConfig, namedGraph);
-                        }
+                        client.executeNamedGraphExport(targetConfig, namedGraph);
                     }
                 });
     }

--- a/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
@@ -17,8 +17,6 @@ import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.lang.StringUtils;
 
-import java.net.URL;
-
 public class ExportRdfGraphJob implements ExportRdfJob {
 
     private final NeptuneSparqlClient client;
@@ -43,12 +41,6 @@ public class ExportRdfGraphJob implements ExportRdfJob {
                     if(StringUtils.isEmpty(namedGraph)) {
                         client.executeCompleteExport(targetConfig);
                     } else {
-                        //Test that namedGraph is a valid URI
-                        try {
-                            new URL(namedGraph).toURI();
-                        } catch (Exception e) {
-                            throw new RuntimeException("Invalid named-graph URI provided", e);
-                        }
                         client.executeNamedGraphExport(targetConfig, namedGraph);
                     }
                 });

--- a/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
@@ -16,14 +16,23 @@ import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 
+import java.util.Collections;
+import java.util.List;
+
 public class ExportRdfGraphJob implements ExportRdfJob {
 
     private final NeptuneSparqlClient client;
     private final RdfTargetConfig targetConfig;
+    private final List<String> namedGraphs;
 
     public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig) {
+        this(client, targetConfig, Collections.emptyList());
+    }
+
+    public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig, List<String> namedGraphs) {
         this.client = client;
         this.targetConfig = targetConfig;
+        this.namedGraphs = namedGraphs;
     }
 
     @Override
@@ -31,7 +40,13 @@ public class ExportRdfGraphJob implements ExportRdfJob {
         Timer.timedActivity("exporting RDF as " + targetConfig.format().description(),
                 (CheckedActivity.Runnable) () -> {
                     System.err.println("Creating statement files");
-                    client.executeCompleteExport(targetConfig);
+                    if(namedGraphs == null || namedGraphs.isEmpty()) {
+                        client.executeCompleteExport(targetConfig);
+                    } else {
+                        for(String namedGraph : namedGraphs) {
+                            client.executeNamedGraphExport(targetConfig, namedGraph);
+                        }
+                    }
                 });
     }
 }

--- a/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
@@ -17,6 +17,8 @@ import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.lang.StringUtils;
 
+import java.net.URL;
+
 public class ExportRdfGraphJob implements ExportRdfJob {
 
     private final NeptuneSparqlClient client;
@@ -24,7 +26,7 @@ public class ExportRdfGraphJob implements ExportRdfJob {
     private final String namedGraph;
 
     public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig) {
-        this(client, targetConfig, null);
+        this(client, targetConfig, "");
     }
 
     public ExportRdfGraphJob(NeptuneSparqlClient client, RdfTargetConfig targetConfig, String namedGraph) {
@@ -41,6 +43,12 @@ public class ExportRdfGraphJob implements ExportRdfJob {
                     if(StringUtils.isEmpty(namedGraph)) {
                         client.executeCompleteExport(targetConfig);
                     } else {
+                        //Test that namedGraph is a valid URI
+                        try {
+                            new URL(namedGraph).toURI();
+                        } catch (Exception e) {
+                            throw new RuntimeException("Invalid named-graph URI provided", e);
+                        }
                         client.executeNamedGraphExport(targetConfig, namedGraph);
                     }
                 });

--- a/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJob.java
@@ -17,9 +17,6 @@ import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.lang.StringUtils;
 
-import java.util.Collections;
-import java.util.List;
-
 public class ExportRdfGraphJob implements ExportRdfJob {
 
     private final NeptuneSparqlClient client;

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -177,7 +177,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
         }
     }
 
-    private void executeGSPExport(RdfTargetConfig targetConfig, String graph) throws IOException {
+    void executeGSPExport(RdfTargetConfig targetConfig, String graph) throws IOException {
         HttpClient httpClient = chooseRepository().getHttpClient();
         HttpUriRequest request = new HttpGet(getGSPEndpoint(graph));
         request.addHeader("Accept", "application/n-triples");

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -189,7 +189,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
         RDFParser rdfParser = Rio.createParser(RDFFormat.NTRIPLES);
         OutputWriter outputWriter = targetConfig.createOutputWriter();
-        RDFWriter writer = targetConfig.createRDFWriter(outputWriter, new FeatureToggles(Collections.emptyList()));
+        RDFWriter writer = targetConfig.createRDFWriter(outputWriter, featureToggles);
         rdfParser.setRDFHandler(writer);
 
         try {

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -42,7 +42,6 @@ import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -172,8 +171,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
     public void executeNamedGraphExport(RdfTargetConfig targetConfig, String namedGraph) throws IOException {
         if(featureToggles.containsFeature(FeatureToggle.No_GSP)) {
-            //TODO:: Needs testing
-            executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } } FROM "+namedGraph, targetConfig);
+            executeTupleQuery(String.format("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <%s>) .}", namedGraph), targetConfig);
         } else {
             executeGSPExport(targetConfig, "graph="+namedGraph);
         }

--- a/src/test/java/com/amazonaws/services/neptune/ExportRdfIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportRdfIntegrationTest.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune;
 
 import com.amazonaws.services.neptune.export.NeptuneExportRunner;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.Rio;
@@ -37,9 +38,33 @@ public class ExportRdfIntegrationTest extends AbstractExportIntegrationTest{
         assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdf/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
     }
 
+    @Test
+    public void testExportRdfSingleNamedGraphVersion() {
+        final String[] command = {"export-rdf", "-e", neptuneEndpoint, "-d", outputDir.getPath(),
+                "--named-graph", "http://aws.amazon.com/neptune/csv2rdf/graph/version"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
+    }
+
+    @Test
+    public void testExportRdfSingleNamedGraphDefault() {
+        final String[] command = {"export-rdf", "-e", neptuneEndpoint, "-d", outputDir.getPath(),
+                "--named-graph", "http://aws.amazon.com/neptune/vocab/v01/DefaultNamedGraph"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdfDefaultNamedGraph/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
+    }
+
     private boolean areStatementsEqual(final String expected, final String actual) {
-        final ArrayList expectedStatements = new ArrayList();
-        final ArrayList actualStatements = new ArrayList();
+        final ArrayList<Statement> expectedStatements = new ArrayList();
+        final ArrayList<Statement> actualStatements = new ArrayList();
         final RDFParser rdfParser = Rio.createParser(RDFFormat.TURTLE);
         rdfParser.setRDFHandler(new StatementCollector(expectedStatements));
         try {

--- a/src/test/java/com/amazonaws/services/neptune/ExportRdfIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportRdfIntegrationTest.java
@@ -62,6 +62,44 @@ public class ExportRdfIntegrationTest extends AbstractExportIntegrationTest{
         assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdfDefaultNamedGraph/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
     }
 
+    @Test
+    public void testExportRdfNoGSP() {
+        final String[] command = {"export-rdf", "-e", neptuneEndpoint, "-d", outputDir.getPath(),
+                "--feature-toggle", "No_GSP"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdf/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
+    }
+
+    @Test
+    public void testExportRdfSingleNamedGraphVersionNoGSP() {
+        final String[] command = {"export-rdf", "-e", neptuneEndpoint, "-d", outputDir.getPath(),
+                "--named-graph", "http://aws.amazon.com/neptune/csv2rdf/graph/version",
+                "--feature-toggle", "No_GSP"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
+    }
+
+    @Test
+    public void testExportRdfSingleNamedGraphDefaultNoGSP() {
+        final String[] command = {"export-rdf", "-e", neptuneEndpoint, "-d", outputDir.getPath(),
+                "--named-graph", "http://aws.amazon.com/neptune/vocab/v01/DefaultNamedGraph",
+                "--feature-toggle", "No_GSP"};
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertTrue("Returned statements don't match expected", areStatementsEqual("src/test/resources/IntegrationTest/testExportRdfDefaultNamedGraph/statements/statements.ttl", resultDir+"/statements/statements.ttl"));
+    }
+
     private boolean areStatementsEqual(final String expected, final String actual) {
         final ArrayList<Statement> expectedStatements = new ArrayList();
         final ArrayList<Statement> actualStatements = new ArrayList();

--- a/src/test/java/com/amazonaws/services/neptune/cli/ExportRDFArgTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cli/ExportRDFArgTest.java
@@ -1,0 +1,70 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.cli;
+
+import com.amazonaws.services.neptune.ExportRdfGraph;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
+
+import static com.github.rvesse.airline.SingleCommand.singleCommand;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+
+public class ExportRDFArgTest {
+
+    @Test
+    public void cannotUseQueryScopeWithoutSparql() {
+        RdfExportScopeModule withSparql = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--rdf-export-scope", "query", "--sparql", "testquery"}));
+        RdfExportScopeModule withoutSparql = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--rdf-export-scope", "query"}));
+
+        assertNotNull(withSparql.createJob(null, null));
+        assertThrows(IllegalStateException.class, ()->{withoutSparql.createJob(null, null);});
+    }
+
+    @Test
+    public void cannotUseInvalidNamedGraphURI() {
+        RdfExportScopeModule validURI = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--named-graph", "http://example.com"}));
+        RdfExportScopeModule whitespace = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--named-graph", " "}));
+        RdfExportScopeModule illegalChar = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--named-graph", "http://example.com/^"}));
+        RdfExportScopeModule noProtocol = getScopeModule(singleCommand(ExportRdfGraph.class).parse(
+                new String[]{"-e", "", "-d", "", "--named-graph", "example.com"}));
+
+        assertNotNull(validURI.createJob(null, null));
+        assertThrows(IllegalArgumentException.class, ()->{whitespace.createJob(null, null);});
+        assertThrows(IllegalArgumentException.class, ()->{illegalChar.createJob(null, null);});
+        assertThrows(IllegalArgumentException.class, ()->{noProtocol.createJob(null, null);});
+    }
+
+    private static RdfExportScopeModule getScopeModule(ExportRdfGraph job) {
+        Field scopeModuleField;
+        try {
+            scopeModuleField = ExportRdfGraph.class.getDeclaredField("exportScope");
+        } catch (NoSuchFieldException e) {
+            throw new RuntimeException(e);
+        }
+
+        scopeModuleField.setAccessible(true);
+
+        try {
+            return (RdfExportScopeModule) scopeModuleField.get(job);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
@@ -32,7 +32,7 @@ public class ExportRdfGraphJobTest {
         RdfTargetConfig mockTarget = mock(RdfTargetConfig.class);
         when(mockTarget.format()).thenReturn(mock(RdfExportFormat.class));
 
-        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget, "test");
+        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget, "http://example.com");
 
         try {
             job.execute();
@@ -40,7 +40,7 @@ public class ExportRdfGraphJobTest {
             //Swallow exceptions due to incomplete mocks
         }
 
-        verify(mockClient, Mockito.times(1)).executeNamedGraphExport(mockTarget, "test");
+        verify(mockClient, Mockito.times(1)).executeNamedGraphExport(mockTarget, "http://example.com");
         verify(mockClient, Mockito.times(0)).executeCompleteExport(Mockito.any());
 
         verifyNoMoreInteractions(mockClient);

--- a/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
 package com.amazonaws.services.neptune.rdf;
 
 import com.amazonaws.services.neptune.rdf.io.RdfExportFormat;

--- a/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/ExportRdfGraphJobTest.java
@@ -1,0 +1,97 @@
+package com.amazonaws.services.neptune.rdf;
+
+import com.amazonaws.services.neptune.rdf.io.RdfExportFormat;
+import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+public class ExportRdfGraphJobTest {
+
+    @Test
+    public void shouldExportExportNamedGraphIfNameProvided() throws IOException {
+        NeptuneSparqlClient mockClient = mock(NeptuneSparqlClient.class);
+        RdfTargetConfig mockTarget = mock(RdfTargetConfig.class);
+        when(mockTarget.format()).thenReturn(mock(RdfExportFormat.class));
+
+        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget, "test");
+
+        try {
+            job.execute();
+        } catch (Exception e) {
+            //Swallow exceptions due to incomplete mocks
+        }
+
+        verify(mockClient, Mockito.times(1)).executeNamedGraphExport(mockTarget, "test");
+        verify(mockClient, Mockito.times(0)).executeCompleteExport(Mockito.any());
+
+        verifyNoMoreInteractions(mockClient);
+    }
+
+    @Test
+    public void shouldDoCompleteExportIfNoNamedGraphProvided() throws IOException {
+        NeptuneSparqlClient mockClient = mock(NeptuneSparqlClient.class);
+        RdfTargetConfig mockTarget = mock(RdfTargetConfig.class);
+        when(mockTarget.format()).thenReturn(mock(RdfExportFormat.class));
+
+        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget);
+
+        try {
+            job.execute();
+        } catch (Exception e) {
+            //Swallow exceptions due to incomplete mocks
+        }
+
+        verify(mockClient, Mockito.times(1)).executeCompleteExport(mockTarget);
+        verify(mockClient, Mockito.times(0)).executeNamedGraphExport(Mockito.any(), Mockito.any());
+
+        verifyNoMoreInteractions(mockClient);
+    }
+
+    @Test
+    public void shouldDoCompleteExportIfNullNamedGraphProvided() throws IOException {
+        NeptuneSparqlClient mockClient = mock(NeptuneSparqlClient.class);
+        RdfTargetConfig mockTarget = mock(RdfTargetConfig.class);
+        when(mockTarget.format()).thenReturn(mock(RdfExportFormat.class));
+
+        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget, null);
+
+        try {
+            job.execute();
+        } catch (Exception e) {
+            //Swallow exceptions due to incomplete mocks
+        }
+
+        verify(mockClient, Mockito.times(1)).executeCompleteExport(mockTarget);
+        verify(mockClient, Mockito.times(0)).executeNamedGraphExport(Mockito.any(), Mockito.any());
+
+        verifyNoMoreInteractions(mockClient);
+    }
+
+    @Test
+    public void shouldDoCompleteExportIfEmptyNamedGraphProvided() throws IOException {
+        NeptuneSparqlClient mockClient = mock(NeptuneSparqlClient.class);
+        RdfTargetConfig mockTarget = mock(RdfTargetConfig.class);
+        when(mockTarget.format()).thenReturn(mock(RdfExportFormat.class));
+
+        ExportRdfGraphJob job = new ExportRdfGraphJob(mockClient, mockTarget, "");
+
+        try {
+            job.execute();
+        } catch (Exception e) {
+            //Swallow exceptions due to incomplete mocks
+        }
+
+        verify(mockClient, Mockito.times(1)).executeCompleteExport(mockTarget);
+        verify(mockClient, Mockito.times(0)).executeNamedGraphExport(Mockito.any(), Mockito.any());
+
+        verifyNoMoreInteractions(mockClient);
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.rdf;
+
+import com.amazonaws.services.neptune.cluster.ConnectionConfig;
+import com.amazonaws.services.neptune.export.FeatureToggle;
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.io.PrintOutputWriter;
+import com.amazonaws.services.neptune.rdf.io.RdfExportFormat;
+import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.io.Writer;
+import java.util.Arrays;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class NeptuneSparqlClientTest {
+
+    private SPARQLRepository mockSPARQLRepository;
+    private SailRepository sailRepository;
+    private final String testDataNTriples = "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://aws.amazon.com/neptune/csv2rdf/class/Version> .\n" +
+            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> \"version\" .\n" +
+            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> \"0.77\" .\n" +
+            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> \"Version: 0.77 Generated: 2017-10-06 16:24:52 UTC\\nGraph created by Kelvin R. Lawrence\\nPlease let me know of any errors you find in the graph.\" .\n";
+
+    @Before
+    public void setup() throws IOException {
+        // init a mock SPARQLRepository which is backed by a SailRepository containing test data.
+        sailRepository = new SailRepository(new MemoryStore());
+        sailRepository.getConnection().add(new File("src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl"));
+        mockSPARQLRepository = mock(SPARQLRepository.class);
+
+        doReturn(sailRepository.getConnection()).when(mockSPARQLRepository).getConnection();
+        doReturn(sailRepository.getHttpClientSessionManager()).when(mockSPARQLRepository).getHttpClientSessionManager();
+        doReturn(sailRepository.getValueFactory()).when(mockSPARQLRepository).getValueFactory();
+    }
+
+    @Test
+    public void testExecuteTupleQuerySelectAll() throws IOException {
+        StringWriter outputWriter = new StringWriter();
+        NeptuneSparqlClient client = createNeptuneSparqlClient();
+
+        // Test data does not have named graphs but a ?g binding is required by TupleQueryHandler
+        client.executeTupleQuery("SELECT * WHERE { BIND(<http://aws.amazon.com/neptune/csv2rdf/graph/version> AS ?g) ?s ?p ?o }", getMockTargetConfig(outputWriter));
+
+        assertEquals(testDataNTriples, outputWriter.toString());
+    }
+
+    @Test
+    public void completeExportShouldExportDefaultGraphViaGSP() throws IOException {
+        NeptuneSparqlClient client = createNeptuneSparqlClient();
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeCompleteExport(targetConfig);
+
+        verify(client, times(1)).executeGSPExport(targetConfig, "default");
+        verify(client, never()).executeTupleQuery(any(), any());
+    }
+
+    @Test
+    public void completeExportShouldExecuteTupleQueryIfNoGSP() throws IOException {
+        NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeCompleteExport(targetConfig);
+
+        verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }", targetConfig);
+        verify(client, never()).executeGSPExport(any(), any());
+    }
+
+    @Test
+    public void namedGraphExportShouldExportDefaultGraphViaGSP() throws IOException {
+        NeptuneSparqlClient client = createNeptuneSparqlClient();
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeNamedGraphExport(targetConfig, "GraphName");
+
+        verify(client, times(1)).executeGSPExport(targetConfig, "graph=GraphName");
+        verify(client, never()).executeTupleQuery(any(), any());
+    }
+
+    @Test
+    public void namedGraphExportShouldExecuteTupleQueryIfNoGSP() throws IOException {
+        NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeNamedGraphExport(targetConfig, "http://example.com");
+
+        verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <http://example.com>) .}", targetConfig);
+        verify(client, never()).executeGSPExport(any(), any());
+    }
+
+    private NeptuneSparqlClient createNeptuneSparqlClient(FeatureToggle ... featureToggles) throws IOException {
+        NeptuneSparqlClient client = spy(NeptuneSparqlClient.create(mock(ConnectionConfig.class), new FeatureToggles(Arrays.asList(featureToggles))));
+
+        doReturn(mockSPARQLRepository).when(client).chooseRepository();
+        doNothing().when(client).executeGSPExport(any(), any());
+
+        return client;
+    }
+
+    private RdfTargetConfig getMockTargetConfig(Writer outputWriter) throws IOException {
+        RdfTargetConfig target = spy(new RdfTargetConfig(null, null, null, RdfExportFormat.ntriples));
+        doReturn(new PrintOutputWriter("TestOutputWriter", outputWriter)).when(target).createOutputWriter();
+
+        return target;
+    }
+}

--- a/src/test/resources/IntegrationTest/testExportRdfDefaultNamedGraph/statements/statements.ttl
+++ b/src/test/resources/IntegrationTest/testExportRdfDefaultNamedGraph/statements/statements.ttl
@@ -1,0 +1,4627 @@
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/6> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "BWI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Baltimore/Washington International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KBWI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-MD";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10502;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 143;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Baltimore";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.917539978E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.666829681E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/62> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    606 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/78> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    424 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/94> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2840 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/110> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    142 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/126> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/142> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    630 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/158> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1746 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/174> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    398 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/190> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2700 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/206> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    629 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/222> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2335 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/238> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    91 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/254> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    859 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/270> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    729 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/286> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    801 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/301> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/317> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    925 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/333> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2263 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/349> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/365> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2059 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/381> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/397> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/413> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/429> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/445> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/461> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/477> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    860 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/493> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    184 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/509> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    417 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/525> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    193 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/541> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1188 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/556> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/572> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1087 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/588> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/604> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1299 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/620> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    863 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/636> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1710 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/652> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2072 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/668> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/684> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/700> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    601 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/716> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/732> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    588 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/748> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2335 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/764> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/780> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/796> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    649 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/811> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    750 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/827> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    324 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/843> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    811 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/859> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    488 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/875> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/891> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2425 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/907> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    354 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/923> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    844 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/939> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2085 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/955> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    601 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/971> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/987> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1003> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1019> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1035> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1051> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    872 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1066> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1082> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    969 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1098> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    488 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1114> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    169 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1130> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2541 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1146> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    694 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1162> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1178> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1194> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1994 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1210> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    985 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1226> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1994 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1242> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1082 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1258> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2124 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1274> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    586 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1290> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1306> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    91 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/17> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "MSP";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Minneapolis-St.Paul International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KMSP";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-MN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11006;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 841;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Minneapolis";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.48819999695E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.32218017578E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/33> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SAT";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "San Antonio";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSAT";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 8505;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 809;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "San Antonio";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.95337009429932E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.84698028564453E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/49> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    945 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/61> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    906 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/77> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    872 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/93> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2519 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/109> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1294 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/125> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1206 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/141> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/157> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    612 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/173> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    368 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/189> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/205> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    278 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/221> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/237> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/253> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/269> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    405 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/285> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/300> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    448 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/316> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/332> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    197 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/348> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    411 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/364> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1822 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/380> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/396> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1630 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/412> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/428> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    737 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/444> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/460> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2280 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/476> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    236 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/492> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    762 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/508> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/524> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/540> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    847 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/555> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/571> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/587> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/603> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    991 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/619> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    409 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/635> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    645 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/651> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1234 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/667> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1452 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/683> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    865 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/699> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/715> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    612 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/731> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2392 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/747> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/763> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2515 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/779> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2130 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/795> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1840 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/810> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2154 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/826> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    417 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/842> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    197 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/858> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/874> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2253 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/890> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1599 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/906> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    965 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/922> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/938> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1930 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/954> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    586 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/970> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    236 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/986> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1069 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1002> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1750 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1018> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1034> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1197 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1050> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    503 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1065> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1480 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1081> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    998 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1097> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1910 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1113> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1129> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1145> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    486 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1161> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1177> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    955 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1193> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    675 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1209> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    675 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1225> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1611 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1241> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    896 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1257> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    96 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1273> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1289> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1434 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1305> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    278 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1320> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1336> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    727 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1352> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    526 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1368> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    486 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1321> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1337> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    596 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1353> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    234 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1369> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    429 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/18> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "ORD";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Chicago O'Hare International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KORD";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-IL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 8;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 13000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 672;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Chicago";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.197859955E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.790480042E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/34> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "MSY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "New Orleans L. Armstrong";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KMSY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-LA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10104;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "New Orleans";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.99934005737305E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.02580032348633E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/20> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "PHX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Phoenix Sky Harbor International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KPHX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-AZ";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11489;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 1135;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Phoenix";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.34342994689941E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.12012001037598E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/36> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "CID";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "The Eastern Iowa Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KCID";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-IA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 8600;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 869;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Cedar Rapids";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.18847007751465E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.17108001708984E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/51> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    546 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/65> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    356 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/81> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4502 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/97> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/113> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    994 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/129> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    444 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/145> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    657 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/161> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/177> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    411 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/193> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/209> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    368 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/225> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    842 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/241> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1313 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/257> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2434 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/273> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    630 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/289> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/304> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    248 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/320> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    901 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/336> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1700 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/352> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    227 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/368> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    955 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/384> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/400> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/416> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    763 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/432> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/448> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2131 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/464> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/480> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/496> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/512> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    404 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/528> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1844 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/544> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    958 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/559> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/575> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/591> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1310 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/50> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    576 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/63> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    546 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/79> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    745 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/95> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2547 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/111> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1520 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/127> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/143> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    793 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/159> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/175> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/191> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2680 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/207> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    577 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/223> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/239> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    408 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/255> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/271> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/287> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/302> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    686 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/318> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    899 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/334> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2322 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/350> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    901 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/366> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/382> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    225 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/398> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    786 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/414> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    760 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/430> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/446> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    423 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/462> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2470 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/478> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/494> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    214 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/510> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    94 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/526> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1310 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/542> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    896 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/557> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    193 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/573> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1044 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/589> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1530 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/605> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    679 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/621> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/637> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1840 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/653> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    314 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/669> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    174 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/685> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/701> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    841 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/717> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/733> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1818 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/749> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1660 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/765> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    965 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/781> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/797> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2392 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/812> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2510 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/828> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    342 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/844> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    786 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/860> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    997 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/876> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/892> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2614 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/908> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    324 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/924> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2433 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/940> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    991 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/956> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1920 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/972> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2169 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/988> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2227 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1004> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1470 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1020> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    965 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1036> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    638 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1052> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    820 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1067> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1129 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1083> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    448 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1099> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1599 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1115> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    199 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1131> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    997 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1147> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    686 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1163> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1179> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1195> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1211> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1227> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1243> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1259> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1493 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1275> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    406 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1291> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1215 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1307> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1322> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1338> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1354> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1370> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    96 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/19> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "PBI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Palm Beach International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KPBI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-FL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 19;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "West Palm Beach";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.66832008361816E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.00955963134766E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/7> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "DCA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Ronald Reagan Washington National Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KDCA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-DC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 7169;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 14;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Washington D.C.";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.88521003723145E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.70376968383789E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/64> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/80> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    694 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/96> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/112> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/128> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    768 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/144> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/160> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1582 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/176> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/192> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/208> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    586 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/224> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2431 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/240> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    547 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/256> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/272> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/288> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    865 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/303> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3770 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/319> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/335> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2173 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/351> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/367> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/383> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    964 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/399> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/415> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1520 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/431> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    427 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/447> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2567 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/463> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/479> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/495> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/511> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/527> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/543> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    863 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/558> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1501 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/574> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1082 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/590> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/606> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1097 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/622> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/638> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1820 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/654> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1830 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/670> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1677 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/686> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/702> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/718> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/734> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/750> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2712 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/766> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    978 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/782> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1963 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/798> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    678 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/813> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/829> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    584 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/845> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/861> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    779 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/877> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    109 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/893> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1310 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/909> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/925> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1350 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/941> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1250 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/957> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1480 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/973> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1299 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/989> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1319 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1005> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    640 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1021> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    946 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1037> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    303 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1053> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1068> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1086 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1084> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1100> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1428 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1116> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1132> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2425 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1148> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1164> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1180> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1196> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1638 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1212> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1677 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1228> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    556 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1244> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    314 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1260> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1953 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1276> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1292> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    750 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1308> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1323> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2510 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1339> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    456 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1355> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1371> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2062 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/607> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1039 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/623> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    801 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/639> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/655> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1434 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/671> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/687> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    369 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/703> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2133 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/719> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    681 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/735> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/751> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/767> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    687 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/783> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2700 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/799> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2387 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/814> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/830> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    386 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/846> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/862> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1236 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/878> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2143 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/894> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    634 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/910> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    352 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/926> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/942> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    508 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/958> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/974> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1510 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/990> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2762 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1006> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1700 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1022> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1038> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1054> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    248 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1069> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1069 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1085> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    955 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1101> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1117> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1065 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1133> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2433 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1149> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1165> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2614 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1181> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    847 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1197> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1330 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1213> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1567 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1229> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1173 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1245> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1021 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1261> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2680 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1277> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2547 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1293> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1309> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    995 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1324> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    922 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1340> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    629 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1356> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    501 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1372> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    727 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/21> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "RDU";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Raleigh-Durham";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KRDU";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 435;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Raleigh";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.58776016235352E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.87874984741211E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/37> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "HNL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Honolulu International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "PHNL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-HI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12312;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 13;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Honolulu";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.13187007904053E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.57921997070312E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/35> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "EWR";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Newark, Liberty";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KEWR";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 17;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Newark";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.06925010681152E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.4168701171875E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/52> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    729 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/66> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/82> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    693 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/98> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/114> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1101 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/130> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/146> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    763 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/162> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    820 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/178> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/194> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/210> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/226> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2295 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/242> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/258> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    815 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/274> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/290> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1660 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/305> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/321> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    964 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/337> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/353> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2280 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/369> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    212 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/385> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/401> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/417> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    186 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/433> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/449> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    93 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/465> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1530 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/481> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/497> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    228 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/513> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    994 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/529> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    534 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/545> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    596 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/560> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1967 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/576> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/592> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1501 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/608> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1008 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/624> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/640> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/656> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    676 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/672> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1023 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/688> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1844 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/704> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/720> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    224 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/736> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    416 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/752> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1870 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/768> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    866 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/784> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/800> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    446 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/815> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1476 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/831> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    946 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/847> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/863> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    928 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/879> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2262 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/895> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    446 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/911> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1910 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/927> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/943> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1818 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/959> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/975> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/991> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1007> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1023> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1039> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1055> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1070> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    795 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1086> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1102> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1118> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    212 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1134> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1969 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1150> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    195 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1166> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2762 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1182> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1198> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1279 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1214> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1557 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1230> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    448 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1246> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1733 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1262> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1278> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1898 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1294> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    367 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1310> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    135 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1325> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1341> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    408 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1357> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1920 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/22> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SEA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Seattle-Tacoma";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSEA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-WA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11901;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 432;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Seattle";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.74490013122559E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.2230899810791E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/38> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "HOU";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Houston Hobby";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KHOU";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 7602;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 46;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Houston";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.964539909E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.527890015E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/53> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    581 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/67> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2130 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/83> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1279 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/99> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/115> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/803> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    597 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/818> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/834> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/850> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/866> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1890 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/882> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/898> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/914> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/930> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/946> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    584 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/962> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/978> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    412 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/994> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    406 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1010> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    860 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1026> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    627 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1042> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    233 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1058> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1073> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    192 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1089> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1105> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    302 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1121> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    938 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1137> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1569 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1153> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    429 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1169> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2405 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1185> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    779 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1201> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    665 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1217> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1573 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1233> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    309 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1249> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    928 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1265> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2567 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1281> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    985 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1297> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    638 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1313> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1328> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1344> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1130 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1360> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/2> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "ANC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Anchorage Ted Stevens";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "PANC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-AK";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12400;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 151;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Anchorage";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 6.11744003295898E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.49996002197266E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/25> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "TPA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Tampa International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KTPA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-FL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11002;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 26;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Tampa";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.79755001068115E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.2533203125E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/833> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/849> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1306 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/865> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    985 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/881> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/897> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    367 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/913> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/929> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/945> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    597 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/961> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1582 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/977> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    866 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/993> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1819 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1009> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1025> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1041> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    166 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1057> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1072> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1569 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1088> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1104> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1167 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1120> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1136> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1152> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1319 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1168> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1184> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1891 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1200> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1216> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1045 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1232> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    313 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1248> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2154 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1264> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2401 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1280> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1638 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1296> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    364 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1312> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    93 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1327> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1343> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    986 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1359> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    985 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/24> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SJC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Norman Y. Mineta San Jose International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSJC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 62;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "San Jose";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.73625984191895E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.21929000854492E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/40> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SJU";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Puerto Rico, Luis Munoz International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "TJSJ";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "PR-U-A";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10400;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 9;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "PR";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "San Juan";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 1.84393997192E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -6.60018005371E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "ATL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Hartsfield - Jackson Atlanta International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KATL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-GA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 5;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12390;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 1026;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Atlanta";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.36366996765137E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.44281005859375E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/55> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    688 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/69> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    406 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/85> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    556 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/101> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2778 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/117> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    866 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/133> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1173 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/149> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    616 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/165> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    669 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/181> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    184 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/197> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1750 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/213> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    184 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/229> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2106 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/245> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    899 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/261> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1470 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/277> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/292> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/308> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1452 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/324> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/340> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    955 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/356> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    922 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/372> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2401 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/388> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/404> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/420> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/436> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/452> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/468> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    369 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/484> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    712 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/500> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/516> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    788 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/532> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2143 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/563> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/579> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/595> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1276 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/611> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/627> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    737 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/643> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1510 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/659> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/675> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    953 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/691> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/707> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    644 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/723> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/739> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    416 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/755> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/771> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2082 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/787> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2577 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/23> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SFO";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "San Francisco International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSFO";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11870;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 13;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "San Francisco";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.76189994812012E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.22375E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/39> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "ELP";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "El Paso International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KELP";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12020;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 3961;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "El Paso";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.180719948E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.063779984E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/54> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    533 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/68> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/84> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/100> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/116> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    973 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/132> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    527 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/148> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    762 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/164> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    745 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/180> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/196> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/212> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/228> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1339 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/244> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/260> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2089 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/276> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/307> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1019 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/323> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2337 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/339> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1065 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/355> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    758 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/371> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    287 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/387> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1420 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/403> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    861 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/419> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    213 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/435> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/451> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1940 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/467> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2324 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/483> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/499> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/515> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/531> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/547> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    806 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/562> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/578> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2519 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/594> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1452 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/610> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3964 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/626> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    926 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/642> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1250 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/658> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    546 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/674> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1021 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/690> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1276 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/706> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1733 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/722> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    427 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/738> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/754> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/770> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1772 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/786> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/802> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    371 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/817> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2431 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/3> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "AUS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Austin Bergstrom International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KAUS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12250;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 542;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Austin";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.01944999694824E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.76698989868164E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/13> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "LAX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Los Angeles International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KLAX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12091;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 127;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Los Angeles";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.394250107E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.184079971E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/71> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/87> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/103> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    755 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/119> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1768 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/135> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/151> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    694 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/167> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1953 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/183> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1260 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/199> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/215> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    788 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/231> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/247> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    213 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/263> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    969 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/279> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    225 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/294> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/310> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/326> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1487 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/342> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1063 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/358> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    587 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/374> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    383 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/390> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/406> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/422> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    227 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/438> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1980 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/41> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "CLE";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Cleveland, Hopkins International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KCLE";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-OH";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 9956;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 799;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Cleveland";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.14117012024E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.18498001099E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/56> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    759 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/70> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1890 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/86> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2124 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/102> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    809 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/118> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1159 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/134> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1493 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/150> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    806 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/166> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    448 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/182> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/198> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    166 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/214> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/230> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/246> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/262> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    233 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/278> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/293> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    927 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/309> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    810 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/325> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    177 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/341> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1045 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/357> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    908 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/373> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    135 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/389> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    963 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/405> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/421> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/437> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/453> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/469> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/485> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2047 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/501> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/517> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    760 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/533> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1930 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/548> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1260 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/564> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    204 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/580> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    694 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/596> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    978 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/612> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1578 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/628> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/644> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/660> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/676> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/692> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/708> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/724> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    431 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/740> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/756> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/772> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2393 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/788> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/819> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/835> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    406 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/851> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    174 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/867> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1160 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/883> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/454> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1790 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/470> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/486> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    337 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/502> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    731 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/518> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    983 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/534> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/549> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    947 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/565> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2262 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/581> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/597> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/613> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1296 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/629> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    731 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/645> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    735 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/661> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    859 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/677> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/693> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1106 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/709> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    369 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/725> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    534 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/741> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    501 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/757> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/773> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/789> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1630 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/804> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    412 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/820> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/836> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    925 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/852> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    588 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/868> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1746 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/884> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    446 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/900> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/916> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/932> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1865 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/948> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/964> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2089 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/980> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1984 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/996> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1012> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1028> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1044> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1075> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1091> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1107> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1898 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1123> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1008 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1139> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1155> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2778 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1171> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    152 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1187> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1350 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1203> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1234 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1219> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1235> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1063 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1251> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1819 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1267> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1578 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1283> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1299> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    708 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1315> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    863 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1330> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1346> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1362> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1480 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/9> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "FLL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Fort Lauderdale/Hollywood International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KFLL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-FL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 9000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 64;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Fort Lauderdale";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.60725994110107E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.0152702331543E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/27> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "LGB";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Long Beach Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KLGB";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10003;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 60;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Long Beach";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.381769943E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.181520004E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/43> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "TUS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Tucson International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KTUS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-AZ";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10996;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 2643;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Tucson";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.21161003112793E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.1094100189209E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/47> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    811 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/57> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1941 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/72> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1910 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/88> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    667 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/104> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1690 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/120> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/136> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/152> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    409 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/168> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/184> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/200> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/216> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    947 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/232> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    998 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/248> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/264> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    199 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/280> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/295> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/311> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/327> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/343> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    995 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/359> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    224 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/375> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    687 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/391> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    926 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/407> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3890 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/423> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/439> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/455> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/471> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/487> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/503> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/519> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    177 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/535> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/550> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    921 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/566> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2085 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/582> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    936 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/598> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1584 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/614> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    977 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/630> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/646> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/662> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/678> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2547 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/694> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    649 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/710> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/726> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    702 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/742> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/758> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1710 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/899> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1950 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/915> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1522 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/931> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/947> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    626 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/963> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2106 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/979> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    386 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/995> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    364 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1011> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1027> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    795 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1043> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1059> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1038 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1074> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    495 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1090> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1106> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    917 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1122> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1087 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1138> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1167 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1154> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4502 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1170> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    693 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1186> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1310 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1202> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    712 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1218> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2004 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1234> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1019 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1250> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2021 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1266> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    337 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1282> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2062 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1298> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1314> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    94 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1329> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    114 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1345> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    383 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1361> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/8> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "DFW";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Dallas/Fort Worth International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KDFW";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 7;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 13401;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 607;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Dallas";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.2896800994873E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.70380020141602E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/26> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport> .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/131> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    152 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/147> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1790 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/163> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    471 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/179> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    186 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/195> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2100 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/211> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    925 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/227> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1865 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/243> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    398 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/259> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2276 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/275> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/291> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/306> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2162 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/322> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/338> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/354> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    228 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/370> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1573 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/386> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/402> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/418> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    184 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/434> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/450> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    507 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/466> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/482> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/498> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1420 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/514> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    616 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/530> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2549 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/546> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1101 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/561> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    702 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/577> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    906 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/593> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    333 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/609> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/625> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    587 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/641> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1720 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/657> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    234 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/673> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1062 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/689> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1967 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/705> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    346 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/721> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/737> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    778 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/753> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/769> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/785> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2434 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/801> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    354 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/816> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2680 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/832> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2541 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/848> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    204 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/864> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    922 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/880> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1532 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/896> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2021 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/912> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1206 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/928> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/944> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    687 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/960> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1080 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/976> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/992> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    582 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1008> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    861 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1024> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    844 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1040> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    780 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1056> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1071> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    493 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1087> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1103> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    493 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1119> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1135> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2227 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1151> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    691 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1167> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3364 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1183> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1199> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    527 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1215> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2162 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1231> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1247> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    416 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1263> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1452 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1279> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2405 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1295> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    601 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1311> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1326> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1920 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1342> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    405 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1358> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2070 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/23> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport> .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/695> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    621 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/711> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1670 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/727> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    978 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/743> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/759> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1106 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/775> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    671 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/791> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/806> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1480 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/822> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1575 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/838> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/854> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2387 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/870> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2296 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/886> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    626 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/902> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/918> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    978 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/934> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1822 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/950> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/966> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2173 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/982> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    255 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/998> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1014> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    679 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1030> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    691 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1046> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    735 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1061> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1097 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1077> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    424 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1093> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    838 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1109> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    928 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1125> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1023 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1141> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1611 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1157> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3890 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1173> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1189> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    882 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1205> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    634 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1221> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1044 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1237> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1253> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    917 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1269> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    644 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1285> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    933 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1301> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    303 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1316> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1332> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    79 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1348> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1364> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/11> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "IAH";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "George Bush Intercontinental";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KIAH";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TX";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 5;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12001;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 96;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Houston";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.99843997955322E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -9.53414001464844E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/29> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SLC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Salt Lake City";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSLC";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-UT";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12002;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 56;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Salt Lake City";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.07883987426758E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.11977996826172E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/30> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "LAS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Las Vegas Mc Carran";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KLAS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NV";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 14512;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 2181;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Las Vegas";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.608010101E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.151520004E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/46> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "DTW";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Detroit Metropolitan, Wayne County";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KDTW";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-MI";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 6;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12003;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 645;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Detroit";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.22123985290527E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.3353401184082E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/48> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    214 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/59> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    404 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/75> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/91> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3260 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/107> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/123> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1160 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/139> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    939 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/155> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/171> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1690 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/187> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2290 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/203> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/219> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/235> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1567 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/251> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    921 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/267> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/283> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    983 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/298> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    640 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/314> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/330> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2712 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/346> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1294 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/362> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    811 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/378> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    657 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/394> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/410> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/426> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/442> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/458> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/474> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    109 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/490> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/506> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/522> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    945 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/538> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/553> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    963 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/569> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/585> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1487 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/601> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1532 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/617> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2840 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/633> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/649> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    195 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/665> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2324 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/681> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2290 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/697> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/713> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1159 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/729> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/745> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/761> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    678 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/777> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/793> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/808> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2560 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/824> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    621 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/840> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    815 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/856> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/872> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1170 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/888> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/904> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2322 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/920> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    342 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/936> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1980 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/952> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1428 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/968> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/984> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    368 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1000> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    768 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1016> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1677 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1032> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    882 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1048> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1063> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    841 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1079> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    471 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1095> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    778 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1111> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1127> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    416 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1143> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2547 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1159> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2550 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1175> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1191> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    302 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1207> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    564 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1223> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1062 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1239> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2047 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1255> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1271> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    446 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1287> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    450 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1303> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1430 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1318> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    676 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1334> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1350> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    958 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1366> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/15> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "MCO";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Orlando International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KMCO";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-FL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 12005;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 96;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Orlando";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.84293994903564E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.13089981079102E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/31> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "DEN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Denver International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KDEN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CO";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 6;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 16000;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 5433;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Denver";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.98616981506348E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.04672996520996E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1142> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    402 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1158> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1174> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1190> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    192 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1206> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    582 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1222> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2072 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1238> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    423 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1254> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    402 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1270> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    671 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1286> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2131 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1302> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    667 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1317> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    977 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1333> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1330 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1349> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    500 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1365> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    503 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/12> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "JFK";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "New York John F. Kennedy International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KJFK";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 14511;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 12;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "New York";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.063980103E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.377890015E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/4> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "BNA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Nashville International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KBNA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-TN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11030;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 599;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Nashville";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.61245002746582E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.66781997680664E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/58> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    761 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/74> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/90> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/106> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1313 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/122> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    925 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/138> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    755 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/154> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    441 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/170> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    945 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/186> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/202> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1677 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/218> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/234> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/250> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    760 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/266> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1557 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/282> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/297> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/313> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    582 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/329> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    681 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/345> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    535 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/361> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/377> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    142 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/393> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/409> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2004 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/425> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    945 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/441> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/457> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/473> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/489> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/505> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/521> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/537> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1038 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/552> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    922 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/568> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1710 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/584> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    852 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/600> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1306 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/616> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    606 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/632> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    333 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/648> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    717 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/664> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/680> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1444 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/696> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    304 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/712> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    356 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/728> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    645 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/744> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1768 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/760> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2347 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/776> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1215 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/792> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/807> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1910 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/823> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1820 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/839> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    842 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/855> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1984 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/871> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2276 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/887> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    258 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/903> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/919> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    371 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/935> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1190 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/951> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1086 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/967> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2059 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/983> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/999> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2400 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1015> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    885 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1031> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3364 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1047> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1060 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1062> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1078> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    444 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1094> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1110> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    745 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1126> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2133 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/45> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "PHL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Philadelphia International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KPHL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-PA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10506;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 36;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Philadelphia";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.9871898651123E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.5241096496582E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/5> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "BOS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Boston Logan";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KBOS";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-MA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 6;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10083;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 19;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Boston" .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/774> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1891 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/790> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/805> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    965 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/821> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    294 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/837> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    612 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/853> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2515 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/869> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2580 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/885> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    417 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/901> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2360 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/917> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    338 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/933> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    986 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/949> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    368 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/965> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1050 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/981> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    258 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/997> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1013> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1710 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1029> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1600 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1045> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1060> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1076> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1092> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1039 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1108> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1124> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    717 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1140> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1156> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3770 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1172> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    669 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1188> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1204> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    346 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1220> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1188 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1236> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    287 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1252> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1197 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1268> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1830 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1284> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    810 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1300> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    369 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1331> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1347> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    507 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1363> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1740 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/10> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "IAD";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Washington Dulles International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KIAD";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-VA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 11500;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 313;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Washington D.C.";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.894449997E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.745580292E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/28> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SNA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Orange County/Santa Ana, John Wayne";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSNA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 5701;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 56;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Santa Ana";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.367570114E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.178679962E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/44> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SAF";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Santa Fe";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSAF";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NM";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 3;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 8366;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 6348;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Santa Fe";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.5617099762E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.06088996887E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/14> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "LGA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "New York La Guardia";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KLGA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 7003;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 20;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "New York";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.077719879E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.387259674E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/73> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/89> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    596 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/105> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1339 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/121> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1476 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/137> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    214 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/153> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1444 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/169> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    456 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/185> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    863 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/201> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1610 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/217> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    936 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/233> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    169 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/249> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    214 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/265> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/281> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/296> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    986 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/312> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    986 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/328> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/344> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1130 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/360> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2300 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/376> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3260 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/392> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/408> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    665 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/424> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2470 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/440> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1620 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/456> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2320 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/472> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    294 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/488> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    708 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/504> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    431 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/520> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    758 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/536> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    972 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/551> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/567> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2169 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/583> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    931 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/599> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1575 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/615> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    526 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/631> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1200 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/647> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    838 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/663> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    954 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/679> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    866 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/5> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat>
+    4.236429977E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.100520325E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/60> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    596 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/76> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    780 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/92> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2340 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/108> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1110 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/124> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1220 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/140> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    586 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/156> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1963 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/172> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    939 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/188> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    612 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/204> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2680 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/220> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1999 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/236> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    313 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/252> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    931 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/268> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    309 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/284> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1120 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/299> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    248 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/315> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    793 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/331> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2577 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/347> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    540 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/363> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2253 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/379> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1590 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/395> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1870 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/411> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    933 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/427> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1020 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/443> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4970 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/459> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2337 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/475> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    589 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/491> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    761 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/507> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1180 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/523> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2210 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/539> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    938 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/554> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1090 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/570> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1140 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/586> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    908 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/602> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1522 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/618> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    973 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/634> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1440 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/650> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    4230 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/666> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1040 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/682> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1999 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/698> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    508 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/714> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    441 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/730> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2347 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/746> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2490 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/762> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    696 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/778> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1920 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/794> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1584 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/809> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2390 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/825> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    696 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/841> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    927 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/857> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1030 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/873> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2263 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/889> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1129 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/905> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2460 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/921> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    226 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/937> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    589 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/953> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1969 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/969> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2240 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/985> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    627 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1001> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1010 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1017> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    601 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1033> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    564 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1049> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    114 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1064> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1772 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1080> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1370 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1096> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2082 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1112> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    745 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1128> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    2393 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1144> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    79 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1160> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    3964 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1176> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    248 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1192> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1410 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1208> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    495 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1224> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1236 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1240> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    417 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1256> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    362 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1272> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    352 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1288> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1296 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1304> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    674 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1319> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    953 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1335> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    362 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1351> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    1150 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/1367> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/dist>
+    928 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/16> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "MIA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Miami International Airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KMIA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-FL";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 13016;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 8;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Miami";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 2.57931995391846E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -8.02906036376953E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/32> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "HPN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Westchester County";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KHPN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-NY";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 2;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 6549;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 439;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "White Plains";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 4.10670013427734E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -7.37076034545898E1 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/26> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "SAN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "San Diego Lindbergh";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KSAN";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 9400;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 16;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "San Diego";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.27336006165E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.17190002441E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/42> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "airport";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "OAK";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> "Oakland";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/icao> "KOAK";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/region> "US-CA";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/runways> 4;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/longest> 10520;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/elev> 9;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/country> "US";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/city> "Oakland";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lat> 3.77212982177734E1;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/lon> -1.22221000671387E2 .
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/3> a <http://aws.amazon.com/neptune/csv2rdf/class/Airport>;

--- a/src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl
+++ b/src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl
@@ -1,0 +1,7 @@
+
+<http://aws.amazon.com/neptune/csv2rdf/resource/0> a <http://aws.amazon.com/neptune/csv2rdf/class/Version>;
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> "version";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> "0.77";
+  <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> """Version: 0.77 Generated: 2017-10-06 16:24:52 UTC
+Graph created by Kelvin R. Lawrence
+Please let me know of any errors you find in the graph.""" .


### PR DESCRIPTION
Issue #, if available: #101

Description of changes:

Adds a new `--named-graph` CLI arg to `export-rdf` which will export a single named graph. Named graphs exports use the Graph Store Protocol and share the same performance and reliability benefits introduced for complete exports in https://github.com/aws/neptune-export/pull/89.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

