### PR TITLE
Fix Apache CommonsCollections Dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Neptune Export v1.1.4 (Release Date: January 11, 2024):
 
+### Bug Fixes:
+
 - Update `--gremlin-filters` to block use of mutating steps `mergeV()` and `mergeE()`
 
 ### New Features and Improvements:

--- a/pom.xml
+++ b/pom.xml
@@ -279,13 +279,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-collections4</artifactId>
-            <version>4.4</version>
-            <scope>test</scope>
-        </dependency>
-
-        <dependency>
             <groupId>org.eclipse.rdf4j</groupId>
             <artifactId>rdf4j-repository-sail</artifactId>
             <version>${rdf4j.version}</version>


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Commons collections was previously added as a test scope dependency, however it was already transitively included through rvesse:airline.

Explicitly declaring it as a test scope dependency has the effect of removing it from the shaded jar artifact.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

