### PR TITLE
Add integration tests to maven and fix flaky test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <javac.target>1.8</javac.target>
         <uberjar.name>neptune-export-${project.version}-all</uberjar.name>
+        <skipIntegrationTests>true</skipIntegrationTests>
+        <neptuneEndpoint></neptuneEndpoint>
         <aws.sdk.version>1.12.359</aws.sdk.version>
         <gremlin.version>3.6.2</gremlin.version>
         <slf4j.version>2.0.5</slf4j.version>
@@ -359,6 +361,10 @@
                 </executions>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.8</version>
@@ -505,6 +511,43 @@
                     </configuration>
                 </plugin>
                 <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>2.22.2</version>
+                    <executions>
+                        <execution>
+                            <id>integration-test</id>
+                            <goals>
+                                <goal>integration-test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/*IntegrationTest.java</include>
+                                </includes>
+                                <skipTests>${skipIntegrationTests}</skipTests>
+                                <forkCount>1</forkCount>
+                                <reuseForks>false</reuseForks>
+                                <summaryFile>target/failsafe-reports/failsafe-integration.xml</summaryFile>
+                                <environmentVariables>
+                                    <NEPTUNE_ENDPOINT>${neptuneEndpoint}</NEPTUNE_ENDPOINT>
+                                </environmentVariables>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>verify-integration-test</id>
+                            <goals>
+                                <goal>verify</goal>
+                            </goals>
+                            <configuration>
+                                <skipTests>${skipIntegrationTests}</skipTests>
+                                <summaryFiles>
+                                    <summaryFile>target/failsafe-reports/failsafe-integration.xml</summaryFile>
+                                </summaryFiles>
+                            </configuration>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>io.github.git-commit-id</groupId>
                     <artifactId>git-commit-id-maven-plugin</artifactId>
                     <version>5.0.0</version>
@@ -535,6 +578,4 @@
             </plugins>
         </pluginManagement>
     </build>
-
-
 </project>

--- a/src/test/java/com/amazonaws/services/neptune/io/KinesisConfigTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/io/KinesisConfigTest.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.io;
 
+import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.services.neptune.cli.AbstractTargetModule;
 import org.junit.Before;
@@ -69,7 +70,9 @@ public class KinesisConfigTest {
     public void shouldUseProvidedCredentialsProvider() {
         when(target.getStreamName()).thenReturn("test");
         when(target.getRegion()).thenReturn("us-west-2");
+        AWSCredentials mockedCreds = mock(AWSCredentials.class);
         AWSCredentialsProvider mockedCredsProvider = mock(AWSCredentialsProvider.class);
+        when(mockedCredsProvider.getCredentials()).thenReturn(mockedCreds);
         when(target.getCredentialsProvider()).thenReturn(mockedCredsProvider);
 
         KinesisConfig config = new KinesisConfig(target);


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Add failsafe plugin to run integration tests through maven. Activated via `-DskipIntegrationTests=false`. A neptune endpoint must be set to the `neptuneEndpoint` system property.

Additionally a small fix is added to resolve a flaky test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

