### PR TITLE
Add '--clone-cluster-enable-audit-logs' argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### New Features and Improvements:
 
-- Add '--clone-cluster-enable-audit-logs' argument which enables audit logging on cloned clusters.
+- Add '--clone-cluster-enable-audit-logs' argument which enables audit logging on cloned clusters. Audit logging is disabled by default, which aligns with previous behavior.
 
 ## Neptune Export v1.1.4 (Release Date: January 11, 2024):
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### New Features and Improvements:
 
+- Add '--clone-cluster-enable-audit-logs' argument which enables audit logging on cloned clusters.
+
 ## Neptune Export v1.1.4 (Release Date: January 11, 2024):
 
 ### Bug Fixes:

--- a/docs/add-clone.md
+++ b/docs/add-clone.md
@@ -4,6 +4,7 @@
     SYNOPSIS
             neptune-export.sh add-clone
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-id <targetClusterId> ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
@@ -17,6 +18,12 @@
                 This option may occur a maximum of 1 times
     
     
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
+                This option may occur a maximum of 1 times
+
+
             --clone-cluster-id <targetClusterId>
                 Cluster ID of the cloned Amazon Neptune database cluster.
     

--- a/docs/create-pg-config.md
+++ b/docs/create-pg-config.md
@@ -7,6 +7,7 @@
                     [ --alb-endpoint <applicationLoadBalancerEndpoint> ]
                     [ {-b | --batch-size} <batchSize> ] [ --clone-cluster ]
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
                     [ {--cluster-id | --cluster | --clusterid} <clusterId> ]
@@ -61,14 +62,20 @@
     
                 This option may occur a maximum of 1 times
     
-    
+
             --clone-cluster-correlation-id <cloneCorrelationId>
                 Correlation ID to be added to a correlation-id tag on the cloned
                 cluster.
     
                 This option may occur a maximum of 1 times
     
-    
+
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
+                This option may occur a maximum of 1 times
+
+        
             --clone-cluster-instance-type <cloneClusterInstanceType>
                 Instance type for cloned cluster (by default neptune-export will
                 use the same instance type as the source cluster).

--- a/docs/export-pg-from-config.md
+++ b/docs/export-pg-from-config.md
@@ -11,6 +11,7 @@
                     [ {-c | --config-file | --filter-config-file} <configFile> ]
                     [ --clone-cluster ]
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
                     [ {--cluster-id | --cluster | --clusterid} <clusterId> ]
@@ -90,12 +91,18 @@
                 Clone an Amazon Neptune cluster.
     
                 This option may occur a maximum of 1 times
-    
+
     
             --clone-cluster-correlation-id <cloneCorrelationId>
                 Correlation ID to be added to a correlation-id tag on the cloned
                 cluster.
     
+                This option may occur a maximum of 1 times
+
+
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
                 This option may occur a maximum of 1 times
     
     

--- a/docs/export-pg-from-queries.md
+++ b/docs/export-pg-from-queries.md
@@ -9,6 +9,7 @@
                     [ --approx-node-count <approxNodeCount> ]
                     [ {-b | --batch-size} <batchSize> ] [ --clone-cluster ]
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
                     [ {--cluster-id | --cluster | --clusterid} <clusterId> ]
@@ -71,12 +72,18 @@
                 Clone an Amazon Neptune cluster.
     
                 This option may occur a maximum of 1 times
-    
+
     
             --clone-cluster-correlation-id <cloneCorrelationId>
                 Correlation ID to be added to a correlation-id tag on the cloned
                 cluster.
     
+                This option may occur a maximum of 1 times
+
+
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
                 This option may occur a maximum of 1 times
     
     

--- a/docs/export-pg.md
+++ b/docs/export-pg.md
@@ -11,6 +11,7 @@
                     [ {-c | --config-file | --filter-config-file} <configFile> ]
                     [ --clone-cluster ]
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
                     [ {--cluster-id | --cluster | --clusterid} <clusterId> ]
@@ -91,15 +92,21 @@
                 Clone an Amazon Neptune cluster.
     
                 This option may occur a maximum of 1 times
-    
-    
+
+
             --clone-cluster-correlation-id <cloneCorrelationId>
                 Correlation ID to be added to a correlation-id tag on the cloned
                 cluster.
     
                 This option may occur a maximum of 1 times
     
+     
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
+                This option may occur a maximum of 1 times
     
+
             --clone-cluster-instance-type <cloneClusterInstanceType>
                 Instance type for cloned cluster (by default neptune-export will
                 use the same instance type as the source cluster).

--- a/docs/export-rdf.md
+++ b/docs/export-rdf.md
@@ -6,6 +6,7 @@
                     [ --alb-endpoint <applicationLoadBalancerEndpoint> ]
                     [ --clone-cluster ]
                     [ --clone-cluster-correlation-id <cloneCorrelationId> ]
+                    [ --clone-cluster-enable-audit-logs ]
                     [ --clone-cluster-instance-type <cloneClusterInstanceType> ]
                     [ --clone-cluster-replica-count <replicaCount> ]
                     [ {--cluster-id | --cluster | --clusterid} <clusterId> ]
@@ -42,7 +43,7 @@
                 Clone an Amazon Neptune cluster.
     
                 This option may occur a maximum of 1 times
-    
+
     
             --clone-cluster-correlation-id <cloneCorrelationId>
                 Correlation ID to be added to a correlation-id tag on the cloned
@@ -50,6 +51,12 @@
     
                 This option may occur a maximum of 1 times
     
+
+            --clone-cluster-enable-audit-logs
+                Enables audit logging on the cloned cluster
+
+                This option may occur a maximum of 1 times
+
     
             --clone-cluster-instance-type <cloneClusterInstanceType>
                 Instance type for cloned cluster (by default neptune-export will

--- a/pom.xml
+++ b/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-inline</artifactId>
-            <version>2.25.0</version>
+            <version>3.4.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/com/amazonaws/services/neptune/AddClone.java
+++ b/src/main/java/com/amazonaws/services/neptune/AddClone.java
@@ -132,10 +132,14 @@ public class AddClone implements Runnable {
     @Once
     private String cloneCorrelationId;
 
+    @Option(name = {"--clone-cluster-enable-audit-logs"}, description = "Enables audit logging on the cloned cluster")
+    @Once
+    private boolean enableAuditLogs;
+
     @Override
     public void run() {
         try {
-            AddCloneTask addCloneTask = new AddCloneTask(sourceClusterId, targetClusterId, cloneClusterInstanceType, replicaCount, engineVersion, awsCli, cloneCorrelationId);
+            AddCloneTask addCloneTask = new AddCloneTask(sourceClusterId, targetClusterId, cloneClusterInstanceType, replicaCount, engineVersion, awsCli, cloneCorrelationId, enableAuditLogs);
             NeptuneClusterMetadata clusterMetadata = addCloneTask.execute();
 
             GetClusterInfo.printClusterDetails(clusterMetadata);

--- a/src/main/java/com/amazonaws/services/neptune/cli/CloneClusterModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/CloneClusterModule.java
@@ -122,6 +122,10 @@ public class CloneClusterModule {
     @Once
     private String cloneCorrelationId;
 
+    @Option(name = {"--clone-cluster-enable-audit-logs"}, description = "Enables audit logging on the cloned cluster")
+    @Once
+    private boolean enableAuditLogs;
+
 
     public CloneClusterModule() {
     }
@@ -144,7 +148,8 @@ public class CloneClusterModule {
                         replicaCount,
                         maxConcurrency,
                         engineVersion,
-                        cloneCorrelationId);
+                        cloneCorrelationId,
+                        enableAuditLogs);
                 return command.cloneCluster(connectionConfig, concurrencyConfig);
             }
         } else {

--- a/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -25,19 +25,22 @@ public class CloneCluster implements CloneClusterStrategy {
     private final int maxConcurrency;
     private final String engineVersion;
     private final String cloneCorrelationId;
+    private final boolean enableAuditLogs;
 
     public CloneCluster(NeptuneClusterMetadata originalClusterMetadata,
                         String cloneClusterInstanceType,
                         int replicaCount,
                         int maxConcurrency,
                         String engineVersion,
-                        String cloneCorrelationId) {
+                        String cloneCorrelationId,
+                        boolean enableAuditLogs) {
         this.originalClusterMetadata = originalClusterMetadata;
         this.cloneClusterInstanceType = cloneClusterInstanceType;
         this.replicaCount = replicaCount;
         this.maxConcurrency = maxConcurrency;
         this.engineVersion = engineVersion;
         this.cloneCorrelationId = cloneCorrelationId;
+        this.enableAuditLogs = enableAuditLogs;
     }
 
     @Override
@@ -57,7 +60,8 @@ public class CloneCluster implements CloneClusterStrategy {
                 replicaCount,
                 engineVersion,
                 originalClusterMetadata.clientSupplier(),
-                cloneCorrelationId);
+                cloneCorrelationId,
+                enableAuditLogs);
 
         NeptuneClusterMetadata targetClusterMetadata = addCloneTask.execute();
 

--- a/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
@@ -1,0 +1,134 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.cluster;
+
+import com.amazonaws.services.neptune.AmazonNeptune;
+import com.amazonaws.services.neptune.model.ApplyMethod;
+import com.amazonaws.services.neptune.model.DBCluster;
+import com.amazonaws.services.neptune.model.DBClusterParameterGroup;
+import com.amazonaws.services.neptune.model.DBInstance;
+import com.amazonaws.services.neptune.model.DBParameterGroup;
+import com.amazonaws.services.neptune.model.DescribeDBClusterParametersResult;
+import com.amazonaws.services.neptune.model.DescribeDBParametersResult;
+import com.amazonaws.services.neptune.model.ModifyDBClusterParameterGroupRequest;
+import com.amazonaws.services.neptune.model.Parameter;
+import com.amazonaws.services.neptune.model.RestoreDBClusterToPointInTimeRequest;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class AddCloneTaskTest {
+
+    @Test
+    public void shouldNotSetAuditLogsWhenEnableAuditLogsIsFalse() {
+        AmazonNeptune mockNeptune = createMockNeptune();
+        ArgumentCaptor<ModifyDBClusterParameterGroupRequest> clusterParamsCaptor = ArgumentCaptor.forClass(ModifyDBClusterParameterGroupRequest.class);
+        ArgumentCaptor<RestoreDBClusterToPointInTimeRequest> cloneClusterRequestCaptor = ArgumentCaptor.forClass(RestoreDBClusterToPointInTimeRequest.class);
+
+        AddCloneTask noLogsTask = new AddCloneTask("sourceClusterId", "targetClusterId", "db_r5_large", 1, null,
+                () -> mockNeptune, null, false);
+
+        // Mock static method to skip creating NeptuneClusterMetadata for test
+        try (MockedStatic<NeptuneClusterMetadata> classMock = mockStatic(NeptuneClusterMetadata.class)) {
+            classMock.when(() -> NeptuneClusterMetadata.createFromClusterId(any(), any())).thenReturn(mock(NeptuneClusterMetadata.class));
+            noLogsTask.execute();
+        }
+
+        verify(mockNeptune).modifyDBClusterParameterGroup(clusterParamsCaptor.capture());
+        verify(mockNeptune).restoreDBClusterToPointInTime(cloneClusterRequestCaptor.capture());
+
+        ModifyDBClusterParameterGroupRequest capturedParamsRequest = clusterParamsCaptor.getValue();
+
+        // Assert that "neptune_enable_audit_log" parameter has not been set
+        assertEquals(0, capturedParamsRequest.getParameters().stream().filter((p) -> (p.getParameterName().equals("neptune_enable_audit_log"))).count());
+
+        RestoreDBClusterToPointInTimeRequest capturedCloneRequest = cloneClusterRequestCaptor.getValue();
+
+        // Assert that cluster log exports are disabled
+        assertEquals(null, capturedCloneRequest.getEnableCloudwatchLogsExports());
+    }
+
+    @Test
+    public void shouldSetAuditLogsWhenEnableAuditLogsIsTrue() {
+        AmazonNeptune mockNeptune = createMockNeptune();
+        ArgumentCaptor<ModifyDBClusterParameterGroupRequest> clusterParamsCaptor = ArgumentCaptor.forClass(ModifyDBClusterParameterGroupRequest.class);
+        ArgumentCaptor<RestoreDBClusterToPointInTimeRequest> cloneClusterRequestCaptor = ArgumentCaptor.forClass(RestoreDBClusterToPointInTimeRequest.class);
+
+        AddCloneTask noLogsTask = new AddCloneTask("sourceClusterId", "targetClusterId", "db_r5_large", 1, null,
+                () -> mockNeptune, null, true);
+
+        // Mock static method to skip creating NeptuneClusterMetadata for test
+        try (MockedStatic<NeptuneClusterMetadata> classMock = mockStatic(NeptuneClusterMetadata.class)) {
+            classMock.when(() -> NeptuneClusterMetadata.createFromClusterId(any(), any())).thenReturn(mock(NeptuneClusterMetadata.class));
+            noLogsTask.execute();
+        }
+
+        verify(mockNeptune).modifyDBClusterParameterGroup(clusterParamsCaptor.capture());
+        verify(mockNeptune).restoreDBClusterToPointInTime(cloneClusterRequestCaptor.capture());
+
+        ModifyDBClusterParameterGroupRequest capturedParamsRequest = clusterParamsCaptor.getValue();
+
+        // Assert that "neptune_enable_audit_log" parameter exists and has been set to "1"
+        assertEquals(1,
+                capturedParamsRequest.getParameters().stream()
+                        .filter((p) -> (p.getParameterName().equals("neptune_enable_audit_log")))
+                        .peek((parameter -> assertEquals("1", parameter.getParameterValue())))
+                        .count());
+
+        RestoreDBClusterToPointInTimeRequest capturedCloneRequest = cloneClusterRequestCaptor.getValue();
+
+        // Assert that cluster audit log exports are enabled
+        assertEquals(Arrays.asList("audit"), capturedCloneRequest.getEnableCloudwatchLogsExports());
+    }
+
+    private AmazonNeptune createMockNeptune() {
+        AmazonNeptune mockNeptune = mock(AmazonNeptune.class);
+        DescribeDBClusterParametersResult mockClusterParamsResult = mock(DescribeDBClusterParametersResult.class);
+        DescribeDBParametersResult mockParamsResult = mock(DescribeDBParametersResult.class);
+
+        DBCluster targetDbCluster = new DBCluster();
+        targetDbCluster.setStatus("available");
+
+        DBInstance targetDbInstance = new DBInstance();
+        targetDbInstance.setDBInstanceStatus("available");
+
+        when(mockNeptune.createDBClusterParameterGroup(any())).thenReturn(mock(DBClusterParameterGroup.class));
+        when(mockNeptune.describeDBClusterParameters(any())).thenReturn(mockClusterParamsResult);
+        when(mockNeptune.createDBParameterGroup(any())).thenReturn(mock(DBParameterGroup.class));
+        when(mockNeptune.describeDBParameters(any())).thenReturn(mockParamsResult);
+        when(mockNeptune.restoreDBClusterToPointInTime(any())).thenReturn(targetDbCluster);
+        when(mockNeptune.createDBInstance(any())).thenReturn(targetDbInstance);
+
+        when(mockClusterParamsResult.getParameters()).thenReturn(Arrays.asList(new Parameter()
+                .withParameterName("neptune_query_timeout")
+                .withParameterValue("2147483647")
+                .withApplyMethod(ApplyMethod.PendingReboot)));
+        when(mockParamsResult.getParameters()).thenReturn(Arrays.asList(new Parameter()
+                .withParameterName("neptune_query_timeout")
+                .withParameterValue("2147483647")
+                .withApplyMethod(ApplyMethod.PendingReboot)));
+
+        return mockNeptune;
+    }
+
+}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Adds new '--clone-cluster-enable-audit-logs' argument which enables audit logging on cloned clusters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

