### PR TITLE
Fix GSP OutputWriter not closed correctly

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -184,20 +184,20 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
         org.apache.http.HttpResponse response = httpClient.execute(request);
         InputStream responseBody = response.getEntity().getContent();
-
         RDFParser rdfParser = Rio.createParser(RDFFormat.NTRIPLES);
-        OutputWriter outputWriter = targetConfig.createOutputWriter();
-        RDFWriter writer = targetConfig.createRDFWriter(outputWriter, featureToggles);
-        rdfParser.setRDFHandler(writer);
 
-        try {
-            rdfParser.parse(responseBody);
+        try (OutputWriter outputWriter = targetConfig.createOutputWriter()) {
+            RDFWriter writer = targetConfig.createRDFWriter(outputWriter, featureToggles);
+            rdfParser.setRDFHandler(writer);
+
+            try {
+                rdfParser.parse(responseBody);
+            } finally {
+                responseBody.close();
+            }
         }
-        catch (IOException e) {
-            throw e;
-        }
-        finally {
-            responseBody.close();
+        catch (Exception e) {
+            throw new RuntimeException(e);
         }
     }
 


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Currently the OutputWriter for GSP based RDF exports is not being closed correctly. This may lead to data loss in certain circumstances as the buffers are not properly flushed and written before export terminates. This PR makes a simple change to ensure the OutputWriter is properly closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

