### PR TITLE
support neptune1.3 during fallback

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
@@ -136,7 +136,11 @@ public class NeptuneClusterMetadata {
 
             if (StringUtils.isNotEmpty(engineVersion) && engineVersion.contains(".")) {
                 int v = Integer.parseInt(engineVersion.split("\\.")[1]);
-                dbParameterGroupFamily = v > 1 ? "neptune1.2" : "neptune1";
+                if (v == 3) {
+                    dbParameterGroupFamily = "neptune1.3";
+                } else {
+                    dbParameterGroupFamily = v > 1 ? "neptune1.2" : "neptune1";
+                }
             } else {
                 dbParameterGroupFamily = "neptune1";
             }


### PR DESCRIPTION
Description of changes:

When deploying neptune-export locally, I get the correct cluster parameter group for our cluster running engine version 1.3.0.1.   Command, using the latest published neptune-export.jar:
```
java -jar neptune-export.jar nesvc \
  --root-path /Users/zacharyp/code/temp \
  --json '{
            "command": "export-pg",
            "outputS3Path" : "s3://somebucket/neptune_export",
            "params": {
              "clusterId" : "foobar",
              "cloneCluster" : true,
              "cloneClusterInstanceType" : "db.r6g.large",
              "cloneClusterEngineVersion" : "1.3.1.0"
              "exportId" : "foobar20240425",
              "scope" : "edges",
              "format" : "json",
              "perLabelDirectories" : true
            }
          }'
```


However, when I run the same command from an ECS instance, I am getting this exception in the logs (faking some data here):

```
INFO - [2024-04-25 17:27:39,891] Cluster ID              : foobar
INFO - [2024-04-25 17:27:39,891] Port                    : 8182
INFO - [2024-04-25 17:27:39,891] Engine                  : 1.3.1.0
INFO - [2024-04-25 17:27:39,891] IAM DB Auth             : false
INFO - [2024-04-25 17:27:39,891] Streams enabled         : false
INFO - [2024-04-25 17:27:39,891] Parameter group family  : neptune1.2
INFO - [2024-04-25 17:27:39,891] Cluster parameter group : foobarneptunedbclusterparams1-3

...

INFO - [2024-04-25 17:27:39,893] Cloning cluster foobar...
INFO - [2024-04-25 17:27:40,338] Source clusterId           : foobar
INFO - [2024-04-25 17:27:40,338] Target clusterId           : neptune-export-cluster-6db25
INFO - [2024-04-25 17:27:40,338] Target instance type       : db.r6g.large
INFO - [2024-04-25 17:27:40,913] DB cluster parameter group : neptune-export-cluster-6db25-db-cluster-params
INFO - [2024-04-25 17:27:40,913] Completed creating DB cluster parameter group in 0 seconds
INFO - [2024-04-25 17:27:41,370] DB parameter group         : neptune-export-cluster-6db25-db-params
INFO - [2024-04-25 17:27:41,370] Completed creating parameter groups in 0 seconds
INFO - [2024-04-25 17:27:41,370] Creating target cluster...
INFO - [2024-04-25 17:27:43,043] An error occurred while creating target cluster. Elapsed time: 1 seconds
INFO - [2024-04-25 17:27:43,043] An error occurred while cloning cluster. Elapsed time: 3 seconds
INFO - [2024-04-25 17:27:43,043] An error occurred while exporting property graph. Elapsed time: 4 seconds
INFO - [2024-04-25 17:27:43,043] com.amazonaws.services.neptune.model.AmazonNeptuneException: The Parameter Group neptune-export-cluster-6db25-db-cluster-params with DBParameterGroupFamily neptune1.2 cannot be used for this instance. Please use a Parameter Group with DBParameterGroupFamily neptune1.3 (Service: AmazonNeptune; Status Code: 400; Error Code: InvalidParameterCombination; Request ID: 009cc573-69a1-445f-a250-df42ff10a061; Proxy: null)

```

I believe that this default to 1.2 must be happening when it runs in ECS?  The task running in ECS does have the permissions required, including `rds:DescribeDBClusterParameters`.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

