### PR TITLE
Surface server errors for RDF GSP exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Amazon Neptune Export CHANGELOG
 
+## Neptune Export v1.1.7 (Release Date: TBD):
+
+- Surface server errors for RDF GSP exports
+
 ## Neptune Export v1.1.6 (Release Date: April 17, 2024):
 
 ### Bug Fixes:

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -207,9 +207,8 @@ public class NeptuneSparqlClient implements AutoCloseable {
                 if (StringUtils.isNotEmpty(serverErrorMessage)) {
                     throw new AmazonServiceException(getErrorMessageFromTrailers(response), e);
                 } else {
-                    // If no trailers are found, assume that e is a genuine parsing failure (likely due to contents of
-                    // response), and not a direct result of a server side error corrupting the response body.
-                    throw e;
+                    throw new RuntimeException("Failed to parse RDF response. This may indicate malformed data in the " +
+                            "results, or a corrupted response from the server potentially due to query execution failure.", e);
                 }
             } finally {
                 responseBody.close();

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -12,6 +12,7 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.rdf;
 
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.auth.AWSCredentialsProvider;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import com.amazonaws.services.neptune.cluster.ConnectionConfig;
@@ -21,9 +22,12 @@ import com.amazonaws.services.neptune.io.OutputWriter;
 import com.amazonaws.services.neptune.rdf.io.NeptuneExportSparqlRepository;
 import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.amazonaws.services.neptune.util.EnvironmentVariableUtils;
+import org.apache.http.Header;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.io.ChunkedInputStream;
+import org.apache.http.util.EntityUtils;
 import org.eclipse.rdf4j.http.client.HttpClientSessionManager;
 import org.eclipse.rdf4j.http.client.RDF4JProtocolSession;
 import org.eclipse.rdf4j.http.client.SPARQLProtocolSession;
@@ -34,6 +38,7 @@ import org.eclipse.rdf4j.repository.base.AbstractRepository;
 import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.eclipse.rdf4j.rio.ParserConfig;
 import org.eclipse.rdf4j.rio.RDFFormat;
+import org.eclipse.rdf4j.rio.RDFParseException;
 import org.eclipse.rdf4j.rio.RDFParser;
 import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
@@ -42,6 +47,9 @@ import org.joda.time.DateTime;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.lang.reflect.Field;
+import java.net.URLDecoder;
 import java.util.List;
 import java.util.Random;
 import java.util.stream.Collectors;
@@ -133,7 +141,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
         } catch (Exception e) {
             if (repository instanceof NeptuneExportSparqlRepository) {
-                throw new RuntimeException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
+                throw new AmazonServiceException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
             }
             else {
                 throw new RuntimeException(e);
@@ -153,7 +161,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
         } catch (Exception e) {
             if (repository instanceof NeptuneExportSparqlRepository) {
-                throw new RuntimeException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
+                throw new AmazonServiceException(((NeptuneExportSparqlRepository) repository).getErrorMessageFromTrailers(), e);
             }
             else {
                 throw new RuntimeException(e);
@@ -181,6 +189,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
         HttpClient httpClient = chooseRepository().getHttpClient();
         HttpUriRequest request = new HttpGet(getGSPEndpoint(graph));
         request.addHeader("Accept", "application/n-triples");
+        request.addHeader("te", "trailers");
 
         org.apache.http.HttpResponse response = httpClient.execute(request);
         InputStream responseBody = response.getEntity().getContent();
@@ -192,6 +201,8 @@ public class NeptuneSparqlClient implements AutoCloseable {
 
             try {
                 rdfParser.parse(responseBody);
+            } catch(RDFParseException e) {
+                throw new AmazonServiceException(getErrorMessageFromTrailers(response), e);
             } finally {
                 responseBody.close();
             }
@@ -215,6 +226,49 @@ public class NeptuneSparqlClient implements AutoCloseable {
                 connectionConfig.endpoints().iterator().next(),
                 connectionConfig.port(),
                 graphName);
+    }
+
+    /**
+     * Attempts to extract error messages from trailing headers from the most recent response received by 'repository'.
+     * If no trailers are found an empty String is returned.
+     */
+    static String getErrorMessageFromTrailers(org.apache.http.HttpResponse response) {
+        if (response == null) {
+            return "";
+        }
+        InputStream responseInStream;
+        try {
+            responseInStream = response.getEntity().getContent();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+        // HTTPClient 4.5.13 provides no methods for accessing trailers from a wrapped stream requiring the use of
+        // reflection to break encapsulation. This bug is being tracked in https://issues.apache.org/jira/browse/HTTPCLIENT-2263.
+        while (!(responseInStream instanceof ChunkedInputStream)){
+            Field wrappedStreamField;
+            try {
+                wrappedStreamField = responseInStream.getClass().getDeclaredField("wrappedStream");
+                wrappedStreamField.setAccessible(true);
+                responseInStream = (InputStream) wrappedStreamField.get(responseInStream);
+                wrappedStreamField.setAccessible(false);
+            } catch (NoSuchFieldException | IllegalAccessException e) {
+                return "";
+            }
+        }
+        // Consume remaining response, ensures trailers have been consumed and are available
+        EntityUtils.consumeQuietly(response.getEntity());
+
+        Header[] trailers = ((ChunkedInputStream) responseInStream).getFooters();
+        StringBuilder messageBuilder = new StringBuilder();
+        for (Header trailer : trailers) {
+            try {
+                messageBuilder.append(URLDecoder.decode(trailer.toString(), "UTF-8"));
+            } catch (UnsupportedEncodingException e) {
+                messageBuilder.append(trailer);
+            }
+            messageBuilder.append('\n');
+        }
+        return messageBuilder.toString();
     }
 
 }


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Previously, GSP based RDF exports were unable to extract any error messages from Neptune in the trailing headers. The changes here will catch parsing exceptions (which is a symptom of a server side error) and attempt to extract additional server failure details from the trailers.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

