### PR TITLE
Configure export to use AWS Batch jobid as export id when available

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.cluster;
 
 import com.amazonaws.services.neptune.AmazonNeptune;
+import org.apache.commons.lang.StringUtils;
 
 import java.util.UUID;
 import java.util.function.Supplier;
@@ -51,7 +52,11 @@ public class CloneCluster implements CloneClusterStrategy {
         }
 
         String clusterId = originalClusterMetadata.clusterId();
-        String targetClusterId = String.format("neptune-export-cluster-%s", UUID.randomUUID().toString().substring(0, 5));
+        String targetClusterIdSuffix = System.getenv("AWS_BATCH_JOB_ID"); // Use AWS Batch job id if running in Neptune Export Service
+        if (StringUtils.isEmpty(targetClusterIdSuffix)) {
+            targetClusterIdSuffix = UUID.randomUUID().toString().substring(0, 5);
+        }
+        String targetClusterId = String.format("neptune-export-cluster-%s", targetClusterIdSuffix);
 
         AddCloneTask addCloneTask = new AddCloneTask(
                 clusterId,

--- a/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -52,7 +52,13 @@ public class CloneCluster implements CloneClusterStrategy {
         }
 
         String clusterId = originalClusterMetadata.clusterId();
-        String targetClusterIdSuffix = System.getenv("AWS_BATCH_JOB_ID"); // Use AWS Batch job id if running in Neptune Export Service
+        String targetClusterIdSuffix = null;
+        try {
+            targetClusterIdSuffix = System.getenv("AWS_BATCH_JOB_ID"); // Use AWS Batch job id if running in Neptune Export Service
+        }
+        catch (SecurityException e) {
+            // Do nothing, will generate new ID if targetClusterIdSuffix is not set.
+        }
         if (StringUtils.isEmpty(targetClusterIdSuffix)) {
             targetClusterIdSuffix = UUID.randomUUID().toString().substring(0, 5);
         }


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Updates export to detect the the job id from environment variables when running inside AWS Batch, instead of generating a new ID.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

