### PR TITLE
fix bug in RDF GSP error message extraction

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -205,7 +205,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
             } catch(RDFParseException e) {
                 String serverErrorMessage = getErrorMessageFromTrailers(response);
                 if (StringUtils.isNotEmpty(serverErrorMessage)) {
-                    throw new AmazonServiceException(getErrorMessageFromTrailers(response), e);
+                    throw new AmazonServiceException(serverErrorMessage, e);
                 } else {
                     throw new RuntimeException("Failed to parse RDF response. This may indicate malformed data in the " +
                             "results, or a corrupted response from the server potentially due to query execution failure.", e);


### PR DESCRIPTION
Issue #, if available: #132

Description of changes:

Corrects a bug in the error message extraction for GSP-based RDF exports. Now in the case of query timeouts or other server side errors, the Neptune Export logs will contain the error message from the server and will look something like this:

```
...
[main] INFO com.amazonaws.services.neptune.io.Status - 800000 (statements)
[main] INFO com.amazonaws.services.neptune.io.Status - 900000 (statements)
[main] INFO com.amazonaws.services.neptune.io.Status - 1000000 (statements)
[main] INFO com.amazonaws.services.neptune.io.Status - 1100000 (statements)

An error occurred while exporting RDF as Turtle. Elapsed time: 17 seconds


An error occurred while exporting rdf graph. Elapsed time: 18 seconds

java.lang.RuntimeException: com.amazonaws.AmazonServiceException: X-Neptune-Status: 500 TimeLimitExceededException
X-Neptune-Detail: {"code":"TimeLimitExceededException","requestId":"bec89714-21ec-7888-e86d-05b23b2be6ba","detailedMessage":"Operation terminated (deadline exceeded)","message":"Operation terminated (deadline exceeded)"}
 (Service: null; Status Code: 0; Error Code: null; Request ID: null; Proxy: null)
	at com.amazonaws.services.neptune.rdf.NeptuneSparqlClient.executeGSPExport(NeptuneSparqlClient.java:218)
	at com.amazonaws.services.neptune.rdf.NeptuneSparqlClient.executeCompleteExport(NeptuneSparqlClient.java:177)
	at com.amazonaws.services.neptune.rdf.ExportRdfGraphJob.lambda$execute$0(ExportRdfGraphJob.java:42)
	at com.amazonaws.services.neptune.util.Timer.timedActivity(Timer.java:41)
	at com.amazonaws.services.neptune.util.Timer.timedActivity(Timer.java:34)
	at com.amazonaws.services.neptune.rdf.ExportRdfGraphJob.execute(ExportRdfGraphJob.java:38)
	at com.amazonaws.services.neptune.ExportRdfGraph.lambda$run$0(ExportRdfGraph.java:77)
	at com.amazonaws.services.neptune.util.Timer.timedActivity(Timer.java:41)
	at com.amazonaws.services.neptune.util.Timer.timedActivity(Timer.java:34)
	at com.amazonaws.services.neptune.ExportRdfGraph.run(ExportRdfGraph.java:60)
	at com.amazonaws.services.neptune.export.NeptuneExportRunner.run(NeptuneExportRunner.java:72)
	at com.amazonaws.services.neptune.ExportRdfIntegrationTest.testExportRdf(ExportRdfIntegrationTest.java:35)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.rules.ExternalResource$1.evaluate(ExternalResource.java:54)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: com.amazonaws.AmazonServiceException: X-Neptune-Status: 500 TimeLimitExceededException
X-Neptune-Detail: {"code":"TimeLimitExceededException","requestId":"bec89714-21ec-7888-e86d-05b23b2be6ba","detailedMessage":"Operation terminated (deadline exceeded)","message":"Operation terminated (deadline exceeded)"}
 (Service: null; Status Code: 0; Error Code: null; Request ID: null; Proxy: null)
	at com.amazonaws.services.neptune.rdf.NeptuneSparqlClient.executeGSPExport(NeptuneSparqlClient.java:208)
	... 41 more
Caused by: org.eclipse.rdf4j.rio.RDFParseException: IRI included an unencoded space:   [line 1187661]
	at org.eclipse.rdf4j.rio.helpers.RDFParserHelper.reportError(RDFParserHelper.java:272)
	at org.eclipse.rdf4j.rio.helpers.AbstractRDFParser.reportError(AbstractRDFParser.java:638)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.reportError(NTriplesParser.java:585)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.parseUriRef(NTriplesParser.java:361)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.parseSubject(NTriplesParser.java:289)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.parseTriple(NTriplesParser.java:242)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.parse(NTriplesParser.java:129)
	at org.eclipse.rdf4j.rio.ntriples.NTriplesParser.parse(NTriplesParser.java:91)
	at org.eclipse.rdf4j.rio.RDFParser.parse(RDFParser.java:167)
	at com.amazonaws.services.neptune.rdf.NeptuneSparqlClient.executeGSPExport(NeptuneSparqlClient.java:204)
	... 41 more
An error occurred while exporting from Neptune: com.amazonaws.AmazonServiceException: X-Neptune-Status: 500 TimeLimitExceededException
X-Neptune-Detail: {"code":"TimeLimitExceededException","requestId":"bec89714-21ec-7888-e86d-05b23b2be6ba","detailedMessage":"Operation terminated (deadline exceeded)","message":"Operation terminated (deadline exceeded)"}
 (Service: null; Status Code: 0; Error Code: null; Request ID: null; Proxy: null)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

