### PR TITLE
Disabled client-side URI verification for export-rdf

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Amazon Neptune Export CHANGELOG
 
+## Neptune Export v1.1.8 (Release Date: TBD):
+
+### Bug Fixes
+
+- Disable client-side verification of URI syntax for export-rdf
+
+### New Features and Improvements:
+
 ## Neptune Export v1.1.7 (Release Date: July 15, 2024):
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazonaws</groupId>
     <artifactId>neptune-export</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8-SNAPSHOT</version>
 
     <licenses>
         <license>

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -57,7 +57,10 @@ import java.util.stream.Collectors;
 
 public class NeptuneSparqlClient implements AutoCloseable {
 
-    private static final ParserConfig PARSER_CONFIG = new ParserConfig().addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX);
+    // Disable client-side URI Syntax verification, defer to Neptune for validation.
+    private static final ParserConfig PARSER_CONFIG = new ParserConfig()
+            .addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX)
+            .set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
 
     public static NeptuneSparqlClient create(ConnectionConfig config, FeatureToggles featureToggles) {
 
@@ -195,11 +198,11 @@ public class NeptuneSparqlClient implements AutoCloseable {
         org.apache.http.HttpResponse response = httpClient.execute(request);
         InputStream responseBody = response.getEntity().getContent();
         RDFParser rdfParser = Rio.createParser(RDFFormat.NTRIPLES);
+        rdfParser.setParserConfig(PARSER_CONFIG);
 
         try (OutputWriter outputWriter = targetConfig.createOutputWriter()) {
             RDFWriter writer = targetConfig.createRDFWriter(outputWriter, featureToggles);
             rdfParser.setRDFHandler(writer);
-
             try {
                 rdfParser.parse(responseBody);
             } catch(RDFParseException e) {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Due to conflicts between the URI verification constraints in Neptune vs in RDF4J, client-side verification in RDF4J is now disabled and Neptune will be the single source of truth for URI verification.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

