### PR TITLE
Update errors in S3 Event Handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### Bug Fixes
 
 - Disable client-side verification of URI syntax for export-rdf
+- Throws exception in cases where S3 Handler cannot find local files
 
 ### New Features and Improvements:
 

--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -322,8 +322,8 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
     private void uploadExportFilesToS3(TransferManager transferManager, File directory, S3ObjectInfo outputS3ObjectInfo) {
 
         if (directory == null || !directory.exists()) {
-            logger.warn("Ignoring request to upload files to S3 because upload directory from which to upload files does not exist");
-            return;
+            logger.error("Request to upload files to S3 failed because upload directory from which to upload files does not exist");
+            throw new RuntimeException("Failed to upload files to S3 because upload directory from which to upload files does not exist");
         }
 
         boolean allowRetry = true;
@@ -331,7 +331,6 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
 
         while (allowRetry){
             try {
-
                 ObjectMetadataProvider metadataProvider = (file, objectMetadata) -> {
                     S3ObjectInfo.createObjectMetadata(file.length(), sseKmsKeyId, objectMetadata);
                 };

--- a/src/test/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandlerTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandlerTest.java
@@ -1,0 +1,47 @@
+package com.amazonaws.services.neptune.export;
+
+import com.amazonaws.auth.AWSCredentialsProvider;
+import com.amazonaws.services.neptune.cluster.Cluster;
+import com.amazonaws.services.neptune.io.Directories;
+import com.amazonaws.services.neptune.propertygraph.ExportStats;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.junit.Test;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+public class ExportToS3NeptuneExportEventHandlerTest {
+
+    @Test
+    public void shouldThrowErrorIfDirectoryMissing() {
+        ExportToS3NeptuneExportEventHandler handler = new ExportToS3NeptuneExportEventHandler(
+                "localOutputPath",
+                "outputS3Path",
+                "s3Region",
+                "completionFileS3Path",
+                mock(ObjectNode.class),
+                false,
+                new ExportToS3NeptuneExportEventHandler.S3UploadParams(),
+                Collections.EMPTY_SET,
+                Collections.EMPTY_SET,
+                "",
+                mock(AWSCredentialsProvider.class)
+        );
+
+        Directories mockDir = mock(Directories.class);
+        when(mockDir.rootDirectory()).thenReturn(Paths.get("nonExistentDirectory"));
+
+        Throwable t = assertThrows(RuntimeException.class, () -> handler.onExportComplete(
+                mockDir, mock(ExportStats.class), mock(Cluster.class)
+        ));
+        assertEquals(
+                "Failed to upload files to S3 because upload directory from which to upload files does not exist",
+                t.getMessage()
+        );
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandlerTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandlerTest.java
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
 package com.amazonaws.services.neptune.export;
 
 import com.amazonaws.auth.AWSCredentialsProvider;


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

In cases where the local export files cannot be found by the ExportToS3NeptuneExportEventHandler, update the logic to throw an exception where previously a warning was simply logged and the upload skipped. The previous logic is viewing the S3 upload as an optional, non-integral part of the export task. This leads to issues in deployments such as the Neptune Export Service in which the local files are temporary and lost once the job is complete. In cases such as these, the S3 upload is a critical.

The update to throw an error in this case will prevent deployments such as the Neptune Export Service from terminating with a successful status in cases where the S3 upload was skipped.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

