### PR TITLE
Refactor GremlinFilters to precompute traversals

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
@@ -31,24 +31,47 @@ public class GremlinFilters {
 
     public static final GremlinFilters EMPTY = new GremlinFilters(null, null, null, false);
 
-    private final String gremlinFilter;
-    private final String gremlinNodeFilter;
-    private final String gremlinEdgeFilter;
+    private final Traversal.Admin<?, ?> gremlinFilter;
+    private final Traversal.Admin<?, ?> gremlinNodeFilter;
+    private final Traversal.Admin<?, ?> gremlinEdgeFilter;
     private final boolean filterEdgesEarly;
 
     private static final List<String> INVALID_OPERATORS = Arrays.asList("addV", "addE", "write", "drop", "sideEffect", "property", "mergeV", "mergeE");
 
     public GremlinFilters(String gremlinFilter, String gremlinNodeFilter, String gremlinEdgeFilter, boolean filterEdgesEarly) {
-        this.gremlinFilter = gremlinFilter;
-        this.gremlinNodeFilter = gremlinNodeFilter;
-        this.gremlinEdgeFilter = gremlinEdgeFilter;
         this.filterEdgesEarly = filterEdgesEarly;
+
+        CachedGremlinScriptEngineManager scriptEngineManager = new CachedGremlinScriptEngineManager();
+        GremlinScriptEngine engine = scriptEngineManager.getEngineByName("gremlin-groovy");
+        Bindings engineBindings = engine.createBindings();
+        engineBindings.put("datetime", new DatetimeConverter());
+
+        try {
+            this.gremlinFilter = StringUtils.isNotEmpty(gremlinFilter) ?
+                    (Traversal.Admin) engine.eval(gremlinFilter, engineBindings) : null;
+        } catch (ScriptException e) {
+            throw new IllegalStateException(String.format("Invalid Gremlin filter: %s. %s", gremlinFilter, e.getMessage()), e);
+        }
+
+        try {
+            this.gremlinNodeFilter = StringUtils.isNotEmpty(gremlinNodeFilter) ?
+                    (Traversal.Admin) engine.eval(gremlinNodeFilter, engineBindings) : null;
+        } catch (ScriptException e) {
+            throw new IllegalStateException(String.format("Invalid Gremlin node filter: %s. %s", gremlinNodeFilter, e.getMessage()), e);
+        }
+
+        try {
+            this.gremlinEdgeFilter = StringUtils.isNotEmpty(gremlinEdgeFilter) ?
+                    (Traversal.Admin) engine.eval(gremlinEdgeFilter, engineBindings) : null;
+        } catch (ScriptException e) {
+            throw new IllegalStateException(String.format("Invalid Gremlin edge filter: %s. %s", gremlinEdgeFilter, e.getMessage()), e);
+        }
     }
 
     public GraphTraversal<? extends Element, ?> applyToNodes(GraphTraversal<? extends Element, ?> t) {
-        if (StringUtils.isNotEmpty(gremlinNodeFilter)) {
+        if (gremlinNodeFilter != null) {
             return apply(t, gremlinNodeFilter);
-        } else if (StringUtils.isNotEmpty(gremlinFilter)) {
+        } else if (gremlinFilter != null) {
             return apply(t, gremlinFilter);
         } else {
             return t;
@@ -56,9 +79,9 @@ public class GremlinFilters {
     }
 
     public GraphTraversal<? extends Element, ?> applyToEdges(GraphTraversal<? extends Element, ?> t) {
-        if (StringUtils.isNotEmpty(gremlinEdgeFilter)) {
+        if (gremlinEdgeFilter != null) {
             return apply(t, gremlinEdgeFilter);
-        } else if (StringUtils.isNotEmpty(gremlinFilter)) {
+        } else if (gremlinFilter != null) {
             return apply(t, gremlinFilter);
         } else {
             return t;
@@ -69,19 +92,8 @@ public class GremlinFilters {
         return filterEdgesEarly;
     }
 
-    private GraphTraversal<? extends Element, ?> apply(GraphTraversal<? extends Element, ?> t, String gremlin) {
-        CachedGremlinScriptEngineManager scriptEngineManager = new CachedGremlinScriptEngineManager();
-        GremlinScriptEngine engine = scriptEngineManager.getEngineByName("gremlin-groovy");
-        Bindings engineBindings = engine.createBindings();
-        engineBindings.put("datetime", new DatetimeConverter());
-
-        Traversal.Admin<?, ?> whereTraversal = null;
-        try {
-            whereTraversal = (Traversal.Admin) engine.eval(gremlin, engineBindings);
-        } catch (ScriptException e) {
-            throw new IllegalStateException(String.format("Invalid Gremlin filter: %s. %s", gremlin, e.getMessage()), e);
-        }
-        for (Bytecode.Instruction instruction : whereTraversal.getBytecode().getInstructions()) {
+    private GraphTraversal<? extends Element, ?> apply(GraphTraversal<? extends Element, ?> t, Traversal.Admin<?, ?> gremlin) {
+        for (Bytecode.Instruction instruction : gremlin.getBytecode().getInstructions()) {
             String operator = instruction.getOperator();
             validateOperator(operator);
             t.asAdmin().getBytecode().addStep(operator, instruction.getArguments());

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
@@ -17,6 +17,8 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class GremlinFiltersTest {
 
@@ -75,6 +77,48 @@ public class GremlinFiltersTest {
 
         assertEquals("__.inject(\"x\").constant(\"node\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
         assertEquals("__.inject(\"x\").constant(\"edge\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldHandleDatetimeFunction() {
+        GremlinFilters filters = new GremlinFilters("constant(datetime(\"2018-03-22T00:35:44.741Z\"))", null, null, false);
+
+        assertEquals("__.inject(\"x\").constant(new Date(1521678944741L))", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(new Date(1521678944741L))", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+
+        filters = new GremlinFilters("constant(datetime(\"2018-03-22T00:35:44.741+1600\"))", null, null, false);
+
+        assertEquals("__.inject(\"x\").constant(new Date(1521621344741L))", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(new Date(1521621344741L))", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldFailOnInvalidGremlinFilter() {
+        assertTrue("Exception does not contain expected message", assertThrows(IllegalStateException.class,
+                ()->new GremlinFilters("notARealGremlinStep()", null, null, false)
+        ).getMessage().contains("Invalid Gremlin filter: notARealGremlinStep()"));
+    }
+
+    @Test
+    public void shouldFailOnInvalidGremlinNodeFilter() {
+        assertTrue("Exception does not contain expected message", assertThrows(IllegalStateException.class,
+                ()->new GremlinFilters(null, "notARealGremlinStep()", null, false)
+        ).getMessage().contains("Invalid Gremlin node filter: notARealGremlinStep()"));
+    }
+
+    @Test
+    public void shouldFailOnInvalidGremlinEdgeFilter() {
+        assertTrue("Exception does not contain expected message", assertThrows(IllegalStateException.class,
+                ()->new GremlinFilters(null, null, "notARealGremlinStep()", false)
+        ).getMessage().contains("Invalid Gremlin edge filter: notARealGremlinStep()"));
+    }
+
+    @Test
+    public void shouldApplyComplexGremlinFilterToNodesAndEdges() {
+        GremlinFilters filters = new GremlinFilters("where(__.or(hasLabel('person'), has('name', 'Cole'))).has('age',inside(20,30))", null, null, false);
+
+        assertEquals("__.inject(\"x\").where(__.or(__.hasLabel(\"person\"),__.has(\"name\",\"Cole\"))).has(\"age\",P.gt((int) 20).and(P.lt((int) 30)))", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").where(__.or(__.hasLabel(\"person\"),__.has(\"name\",\"Cole\"))).has(\"age\",P.gt((int) 20).and(P.lt((int) 30)))", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
     }
 
     private GraphTraversal anonymousTraversal() {

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
@@ -1,0 +1,72 @@
+package com.amazonaws.services.neptune.propertygraph;
+
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
+import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class GremlinFiltersTest {
+
+
+    @Test
+    public void shouldNotModifyTraversalWithNoFilters() {
+        GremlinFilters filters = new GremlinFilters(null, null, null, false);
+
+        assertEquals("__.inject(\"x\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldApplyGremlinFilterToNodesAndEdges() {
+        GremlinFilters filters = new GremlinFilters("constant(\"both\")", null, null, false);
+
+        assertEquals("__.inject(\"x\").constant(\"both\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(\"both\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldPreferFilterNodesOnly() {
+        GremlinFilters filters = new GremlinFilters(null, "constant(\"node\")", null, false);
+
+        assertEquals("__.inject(\"x\").constant(\"node\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldPreferFilterEdgesOnly() {
+        GremlinFilters filters = new GremlinFilters(null, null, "constant(\"edge\")", false);
+
+        assertEquals("__.inject(\"x\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(\"edge\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldPreferSpecificFilters() {
+        GremlinFilters filters = new GremlinFilters("constant(\"both\")", "constant(\"node\")", "constant(\"edge\")", false);
+
+        assertEquals("__.inject(\"x\").constant(\"node\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(\"edge\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldWorkWithRepeatedUse() {
+        GremlinFilters filters = new GremlinFilters("constant(\"both\")", "constant(\"node\")", "constant(\"edge\")", false);
+
+        filters.applyToNodes(anonymousTraversal());
+        filters.applyToNodes(anonymousTraversal());
+        filters.applyToNodes(anonymousTraversal());
+
+        filters.applyToEdges(anonymousTraversal());
+        filters.applyToEdges(anonymousTraversal());
+        filters.applyToEdges(anonymousTraversal());
+
+        assertEquals("__.inject(\"x\").constant(\"node\")", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").constant(\"edge\")", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    private GraphTraversal anonymousTraversal() {
+        return __.inject("x");
+    }
+
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
@@ -1,3 +1,15 @@
+/*
+Copyright 2024 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
 package com.amazonaws.services.neptune.propertygraph;
 
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:
Updates GremlinFilters such that all filters are processed into GraphTraversal's on construction, instead of during filter application. This significantly reduces the overhead when applying the filter to a large number of traversals.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

