### PR TITLE
TinkerPop and JanusGraph Upgrade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Amazon Neptune Export CHANGELOG
 
+## Neptune Export v1.1.10 (Release Date: TBD):
+
+### Bug Fixes:
+
+### New Features and Improvements:
+
+- Update TinkerPop to 3.7.3 and JanusGraph to 1.1.0
+
 ## Neptune Export v1.1.9 (Release Date: Nov 12, 2024):
 
 ### Bug Fixes

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <skipIntegrationTests>true</skipIntegrationTests>
         <neptuneEndpoint></neptuneEndpoint>
         <aws.sdk.version>1.12.773</aws.sdk.version>
-        <gremlin.version>3.6.2</gremlin.version>
+        <gremlin.version>3.7.3</gremlin.version>
         <slf4j.version>2.0.5</slf4j.version>
         <rdf4j.version>3.5.0</rdf4j.version>
         <amazon.neptune.sigv4.signer.version>2.4.0</amazon.neptune.sigv4.signer.version>
@@ -38,15 +38,27 @@
         <dependency>
             <groupId>org.janusgraph</groupId>
             <artifactId>janusgraph-driver</artifactId>
-            <version>0.5.3</version>
+            <version>1.1.0</version>
             <exclusions>
                 <exclusion>
                     <groupId>org.apache.tinkerpop</groupId>
                     <artifactId>gremlin-core</artifactId>
                 </exclusion>
                 <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-driver</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.tinkerpop</groupId>
+                    <artifactId>gremlin-groovy</artifactId>
+                </exclusion>
+                <exclusion>
                     <groupId>org.apache.commons</groupId>
                     <artifactId>commons-text</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-api</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphSerializationModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphSerializationModule.java
@@ -14,19 +14,17 @@ package com.amazonaws.services.neptune.cli;
 
 import com.amazonaws.services.neptune.propertygraph.NeptuneGremlinClient;
 import com.amazonaws.services.neptune.propertygraph.io.SerializationConfig;
-import com.amazonaws.services.neptune.propertygraph.schema.TokensOnly;
 import com.github.rvesse.airline.annotations.Option;
 import com.github.rvesse.airline.annotations.restrictions.AllowedEnumValues;
-import com.github.rvesse.airline.annotations.restrictions.AllowedValues;
 import com.github.rvesse.airline.annotations.restrictions.Once;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 
 public class PropertyGraphSerializationModule {
 
     @Option(name = {"--serializer"}, description = "Message serializer – (optional, default 'GRAPHBINARY_V1D0').")
     @AllowedEnumValues(Serializers.class)
     @Once
-    private String serializer = Serializers.GRAPHBINARY_V1D0.name();
+    private String serializer = Serializers.GRAPHBINARY_V1.name();
 
     @Option(name = {"--janus"}, description = "Use JanusGraph serializer.")
     @Once

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/SerializationConfig.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/SerializationConfig.java
@@ -13,11 +13,9 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.propertygraph.io;
 
 import org.apache.tinkerpop.gremlin.driver.Cluster;
-import org.apache.tinkerpop.gremlin.driver.MessageSerializer;
-import org.apache.tinkerpop.gremlin.driver.ser.GraphBinaryMessageSerializerV1;
-import org.apache.tinkerpop.gremlin.driver.ser.GraphSONMessageSerializerV3d0;
+import org.apache.tinkerpop.gremlin.util.MessageSerializer;
+import org.apache.tinkerpop.gremlin.util.ser.GraphSONMessageSerializerV3;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -43,7 +41,7 @@ public class SerializationConfig {
         if (useJanusSerializer) {
             Map<String, Object> config = new HashMap<>();
             config.put("ioRegistries", Collections.singletonList("org.janusgraph.graphdb.tinkerpop.JanusGraphIoRegistry"));
-            MessageSerializer s = new GraphSONMessageSerializerV3d0();
+            MessageSerializer s = new GraphSONMessageSerializerV3();
             s.configure(config, null);
             return b.serializer(s);
         } else {

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClientTest.java
@@ -19,7 +19,7 @@ import com.amazonaws.services.neptune.propertygraph.io.SerializationConfig;
 import org.apache.tinkerpop.gremlin.driver.Cluster;
 import org.apache.tinkerpop.gremlin.driver.HandshakeInterceptor;
 import org.apache.tinkerpop.gremlin.driver.LBAwareSigV4WebSocketChannelizer;
-import org.apache.tinkerpop.gremlin.driver.ser.Serializers;
+import org.apache.tinkerpop.gremlin.util.ser.Serializers;
 import org.junit.Test;
 import org.apache.tinkerpop.gremlin.driver.Client;
 
@@ -39,7 +39,7 @@ import static org.mockito.Mockito.when;
 public class NeptuneGremlinClientTest {
 
     private final SerializationConfig defaultSerializationConfig = new SerializationConfig(
-            Serializers.GRAPHBINARY_V1D0.name(), 50000000, NeptuneGremlinClient.DEFAULT_BATCH_SIZE, false);
+            Serializers.GRAPHBINARY_V1.name(), 50000000, NeptuneGremlinClient.DEFAULT_BATCH_SIZE, false);
 
     @Test
     public void testQueryClientSubmit() {
@@ -96,7 +96,7 @@ public class NeptuneGremlinClientTest {
         HandshakeInterceptor interceptor;
 
         try {
-            Method getHandshakeInterceptor = cluster.getClass().getDeclaredMethod("getHandshakeInterceptor");
+            Method getHandshakeInterceptor = cluster.getClass().getDeclaredMethod("getRequestInterceptor");
             getHandshakeInterceptor.setAccessible(true);
             interceptor = (HandshakeInterceptor) getHandshakeInterceptor.invoke(cluster);
             getHandshakeInterceptor.setAccessible(false);


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Upgrade TinkerPop dependencies to 3.7.3 and JanusGraph Driver to 1.1.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

