### PR TITLE
Update scheme from http(s) to ws(s) for NLB endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- Fix incorrect URL scheme for network load balancer endpoints
+
 ## Neptune Export v1.1.10 (Release Date: Dec 16, 2024):
 
 ### New Features and Improvements:

--- a/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
+++ b/src/main/java/org/apache/tinkerpop/gremlin/driver/LBAwareSigV4WebSocketChannelizer.java
@@ -192,4 +192,9 @@ public class LBAwareSigV4WebSocketChannelizer extends Channelizer.AbstractChanne
                 handshakeRequestConfig);
         return new WebSocketClientHandler(handshaker, 10000, supportsSsl());
     }
+
+    @Override
+    public String getScheme(boolean sslEnabled) {
+        return sslEnabled ? "wss" : "ws";
+    }
 }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

This is in response to a change introduced by TinkerPop 3.7 which changed the default Channelizer scheme from ws(s) to http(s). The NLB configuration in Neptune Export requires the use of `ws` or `wss`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

