### PR TITLE
Fix artifact signing workflow

### DIFF
--- a/.github/workflows/maven_build_and_verify.yml
+++ b/.github/workflows/maven_build_and_verify.yml
@@ -71,7 +71,7 @@ jobs:
           ls -l ./target
           echo "Path = ./target/neptune-export-${version}-all.jar"
         
-          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body ./target/neptune-export-${version}-all.jar  --acl bucket-owner-full-control | jq '.VersionId' )
+          version_id=$( aws s3api put-object --bucket ${{ secrets.AWS_UNSIGNED_BUCKET }} --key ${{ secrets.AWS_KEY }} --body ./target/neptune-export-${version}-all.jar  --acl bucket-owner-full-control | jq -r '.VersionId' )
           job_id=""
           # Attempt to get Job ID from bucket tagging, will retry up to 3 times before exiting with a failure code.
           # Will sleep for 5 seconds between retries.


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Fixes artifact signing workflow, which was failing due to extra quotes around the `version_id`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

