### PR TITLE
Fix missing headers in csv output and enable schema inference in export-pg-from-queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,12 @@
 ### New Features and Improvements:
 
 - Migrate to AWS SDK for Java v2
+- Enable csv file rewrites for `export-pg-from-queries` to ensure output conforms to inferred schema
 
 ### Bug Fixes:
 
 - Add retries to Neptune clone creation
+- Fix missing csv headers from `export-pg-from-queries`
 
 ## Neptune Export v1.1.11 (Release Date: Mar 10, 2025):
 

--- a/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
+++ b/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
@@ -123,7 +123,7 @@ public class ExportPropertyGraphFromGremlinQueries extends NeptuneExportCommand 
                     CsvPrinterOptions csvPrinterOptions = CsvPrinterOptions.builder().setIncludeTypeDefinitions(includeTypeDefinitions).build();
                     JsonPrinterOptions jsonPrinterOptions = JsonPrinterOptions.builder().setStrictCardinality(true).build();
 
-                    PropertyGraphTargetConfig targetConfig = target.config(directories, new PrinterOptions(csvPrinterOptions, jsonPrinterOptions));
+                    PropertyGraphTargetConfig targetConfig = target.config(directories, new PrinterOptions(csvPrinterOptions, jsonPrinterOptions), structuredOutput);
                     NamedQueriesCollection namedQueries = getNamedQueriesCollection(queries, queriesFile, queriesResource);
 
                     GraphSchema graphSchema = new GraphSchema();

--- a/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
+++ b/src/main/java/com/amazonaws/services/neptune/ExportPropertyGraphFromGremlinQueries.java
@@ -123,7 +123,7 @@ public class ExportPropertyGraphFromGremlinQueries extends NeptuneExportCommand 
                     CsvPrinterOptions csvPrinterOptions = CsvPrinterOptions.builder().setIncludeTypeDefinitions(includeTypeDefinitions).build();
                     JsonPrinterOptions jsonPrinterOptions = JsonPrinterOptions.builder().setStrictCardinality(true).build();
 
-                    PropertyGraphTargetConfig targetConfig = target.config(directories, new PrinterOptions(csvPrinterOptions, jsonPrinterOptions), structuredOutput);
+                    PropertyGraphTargetConfig targetConfig = target.config(directories, new PrinterOptions(csvPrinterOptions, jsonPrinterOptions));
                     NamedQueriesCollection namedQueries = getNamedQueriesCollection(queries, queriesFile, queriesResource);
 
                     GraphSchema graphSchema = new GraphSchema();
@@ -168,8 +168,10 @@ public class ExportPropertyGraphFromGremlinQueries extends NeptuneExportCommand 
                     directories.writeResultsDirectoryPathAsMessage(target.description(), target);
 
                     queriesResource.writeResourcePathAsMessage(target);
-                    configFileResource.save(graphSchema, false);
-                    statsFileResource.save(exportStats, graphSchema);
+                    if (structuredOutput) {
+                        configFileResource.save(graphSchema, false);
+                        statsFileResource.save(exportStats, graphSchema);
+                    }
 
                     directories.writeRootDirectoryPathAsReturnValue(target);
                     onExportComplete(directories, exportStats, cluster, graphSchema);

--- a/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphTargetModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphTargetModule.java
@@ -42,10 +42,6 @@ public class PropertyGraphTargetModule extends AbstractTargetModule {
     }
 
     public PropertyGraphTargetConfig config(Directories directories, PrinterOptions printerOptions){
-        return config(directories, printerOptions, true);
-    }
-
-    public PropertyGraphTargetConfig config(Directories directories, PrinterOptions printerOptions, boolean inferSchema){
 
         if (mergeFiles && (format != PropertyGraphExportFormat.csv && format != PropertyGraphExportFormat.csvNoHeaders)){
             throw new IllegalArgumentException("Merge files is only supported for CSV formats for export-pg");
@@ -53,7 +49,7 @@ public class PropertyGraphTargetModule extends AbstractTargetModule {
 
         KinesisConfig kinesisConfig = new KinesisConfig(this);
 
-        return new PropertyGraphTargetConfig(directories, kinesisConfig, printerOptions, format, getOutput(), mergeFiles, perLabelDirectories, inferSchema);
+        return new PropertyGraphTargetConfig(directories, kinesisConfig, printerOptions, format, getOutput(), mergeFiles, perLabelDirectories, true);
     }
 
     public String description(){

--- a/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphTargetModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/PropertyGraphTargetModule.java
@@ -42,6 +42,10 @@ public class PropertyGraphTargetModule extends AbstractTargetModule {
     }
 
     public PropertyGraphTargetConfig config(Directories directories, PrinterOptions printerOptions){
+        return config(directories, printerOptions, true);
+    }
+
+    public PropertyGraphTargetConfig config(Directories directories, PrinterOptions printerOptions, boolean inferSchema){
 
         if (mergeFiles && (format != PropertyGraphExportFormat.csv && format != PropertyGraphExportFormat.csvNoHeaders)){
             throw new IllegalArgumentException("Merge files is only supported for CSV formats for export-pg");
@@ -49,7 +53,7 @@ public class PropertyGraphTargetModule extends AbstractTargetModule {
 
         KinesisConfig kinesisConfig = new KinesisConfig(this);
 
-        return new PropertyGraphTargetConfig(directories, kinesisConfig, printerOptions, format, getOutput(), mergeFiles, perLabelDirectories, true);
+        return new PropertyGraphTargetConfig(directories, kinesisConfig, printerOptions, format, getOutput(), mergeFiles, perLabelDirectories, inferSchema);
     }
 
     public String description(){

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryJob.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryJob.java
@@ -89,6 +89,7 @@ public class QueryJob {
 
         Collection<FileSpecificLabelSchemas> nodesFileSpecificLabelSchemas = new ArrayList<>();
         Collection<FileSpecificLabelSchemas> edgesFileSpecificLabelSchemas = new ArrayList<>();
+        Collection<FileSpecificLabelSchemas> queryResultsFileSpecificLabelSchemas = new ArrayList<>();
 
         LabelsFilter nodeLabelFilter = new AllLabels(NodeLabelStrategy.nodeLabelsOnly);
         LabelsFilter edgeLabelFilter = new AllLabels(EdgeLabelStrategy.edgeLabelsOnly);
@@ -97,7 +98,7 @@ public class QueryJob {
             if (exportSpecification.getGraphElementType() == GraphElementType.nodes) {
                 nodeLabelFilter = exportSpecification.getLabelsFilter();
             }
-            else {
+            else if (exportSpecification.getGraphElementType() == GraphElementType.edges) {
                 edgeLabelFilter = exportSpecification.getLabelsFilter();
             }
         }
@@ -139,18 +140,28 @@ public class QueryJob {
             Map<GraphElementType, FileSpecificLabelSchemas> result = future.get();
             nodesFileSpecificLabelSchemas.add(result.get(GraphElementType.nodes));
             edgesFileSpecificLabelSchemas.add(result.get(GraphElementType.edges));
+            queryResultsFileSpecificLabelSchemas.add(result.get(GraphElementType.queryResults));
         }
 
         RewriteCommand rewriteCommand = targetConfig.createRewriteCommand(concurrencyConfig, featureToggles);
         Map<GraphElementType, GraphElementSchemas> graphElementSchemas = new HashMap<>();
 
-        for(ExportSpecification exportSpecification : exportSpecifications) {
-            MasterLabelSchemas masterLabelSchemas = exportSpecification.createMasterLabelSchemas(
-                    exportSpecification.getGraphElementType().equals(GraphElementType.nodes) ?
-                            nodesFileSpecificLabelSchemas : edgesFileSpecificLabelSchemas
-            );
+        if (structuredOutput) {
+            for(ExportSpecification exportSpecification : exportSpecifications) {
+                MasterLabelSchemas masterLabelSchemas = exportSpecification.createMasterLabelSchemas(
+                        exportSpecification.getGraphElementType().equals(GraphElementType.nodes) ?
+                                nodesFileSpecificLabelSchemas : edgesFileSpecificLabelSchemas
+                );
+                try {
+                    graphElementSchemas.put(exportSpecification.getGraphElementType(), rewriteCommand.execute(masterLabelSchemas).toGraphElementSchemas());
+                } catch (Exception e) {
+                    throw new RuntimeException(e);
+                }
+            }
+        } else {
+            MasterLabelSchemas masterLabelSchemas = new MasterLabelSchemas(queryResultsFileSpecificLabelSchemas, GraphElementType.queryResults);
             try {
-                graphElementSchemas.put(exportSpecification.getGraphElementType(), rewriteCommand.execute(masterLabelSchemas).toGraphElementSchemas());
+                graphElementSchemas.put(GraphElementType.queryResults, rewriteCommand.execute(masterLabelSchemas).toGraphElementSchemas());
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/QueryTask.java
@@ -91,6 +91,7 @@ public class QueryTask implements Callable<Map<GraphElementType, FileSpecificLab
         Map<GraphElementType, FileSpecificLabelSchemas> fileSpecificLabelSchemasMap = new HashMap<>();
         fileSpecificLabelSchemasMap.put(GraphElementType.nodes, new FileSpecificLabelSchemas());
         fileSpecificLabelSchemasMap.put(GraphElementType.edges, new FileSpecificLabelSchemas());
+        fileSpecificLabelSchemasMap.put(GraphElementType.queryResults, new FileSpecificLabelSchemas());
 
         try {
 
@@ -186,6 +187,7 @@ public class QueryTask implements Callable<Map<GraphElementType, FileSpecificLab
         }
         else {
             ResultsHandler resultsHandler = new ResultsHandler(
+                    fileSpecificLabelSchemasMap.get(GraphElementType.queryResults),
                     new Label(namedQuery.name()),
                     labelWriters,
                     writerFactory,
@@ -219,8 +221,10 @@ public class QueryTask implements Callable<Map<GraphElementType, FileSpecificLab
         private final Map<Label, LabelWriter<Map<?, ?>>> labelWriters;
         private final QueriesWriterFactory writerFactory;
         private final GraphElementSchemas graphElementSchemas;
+        private final FileSpecificLabelSchemas fileSpecificLabelSchemas;
 
-        private ResultsHandler(Label label,
+        private ResultsHandler(FileSpecificLabelSchemas fileSpecificLabelSchemas,
+                               Label label,
                                Map<Label, LabelWriter<Map<?, ?>>> labelWriters,
                                QueriesWriterFactory writerFactory,
                                GraphElementSchemas graphElementSchemas) {
@@ -229,6 +233,7 @@ public class QueryTask implements Callable<Map<GraphElementType, FileSpecificLab
             this.writerFactory = writerFactory;
 
             this.graphElementSchemas = graphElementSchemas;
+            this.fileSpecificLabelSchemas = fileSpecificLabelSchemas;
         }
 
         private void createWriter(Map<?, ?> properties, boolean allowStructuralElements) {
@@ -242,7 +247,10 @@ public class QueryTask implements Callable<Map<GraphElementType, FileSpecificLab
                 PropertyGraphPrinter propertyGraphPrinter =
                         writerFactory.createPrinter(Directories.fileName(label.fullyQualifiedLabel(), index), labelSchema, targetConfig);
 
-                labelWriters.put(label, writerFactory.createLabelWriter(propertyGraphPrinter, label));
+                LabelWriter<Map<?, ?>> labelWriter = writerFactory.createLabelWriter(propertyGraphPrinter, label);
+
+                labelWriters.put(label, labelWriter);
+                fileSpecificLabelSchemas.add(labelWriter.outputId(), targetConfig.format(), labelSchema);
 
             } catch (IOException e) {
                 throw new RuntimeException(e);

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsv.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsv.java
@@ -157,7 +157,7 @@ public class RewriteAndMergeCsv implements RewriteCommand {
 
                             if (graphElementType == GraphElementType.nodes) {
                                 printer.printNode(record.get("~id"), Arrays.asList(record.get("~label").split(";")));
-                            } else {
+                            } else if (graphElementType == GraphElementType.edges) {
                                 if (label.hasFromAndToLabels()) {
                                     printer.printEdge(
                                             record.get("~id"),

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsv.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsv.java
@@ -158,7 +158,7 @@ public class RewriteCsv implements RewriteCommand {
 
                     if (graphElementType == GraphElementType.nodes) {
                         target.printNode(record.get("~id"), Arrays.asList(record.get("~label").split(";")));
-                    } else {
+                    } else if (graphElementType == GraphElementType.edges) {
                         if (label.hasFromAndToLabels()) {
                             target.printEdge(
                                     record.get("~id"),

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/ExportSpecification.java
@@ -121,40 +121,7 @@ public class ExportSpecification {
     }
 
     public MasterLabelSchemas createMasterLabelSchemas(Collection<FileSpecificLabelSchemas> fileSpecificLabelSchemasCollection) {
-
-        Set<Label> labels = new HashSet<>();
-
-        fileSpecificLabelSchemasCollection.forEach(s -> labels.addAll(s.labels()));
-
-        Map<Label, MasterLabelSchema> masterLabelSchemas = new HashMap<>();
-
-        for (Label label : labels) {
-
-            LabelSchema masterLabelSchema = new LabelSchema(label);
-            Collection<FileSpecificLabelSchema> fileSpecificLabelSchemas = new ArrayList<>();
-
-            for (FileSpecificLabelSchemas fileSpecificLabelSchemasForTask : fileSpecificLabelSchemasCollection) {
-                if (fileSpecificLabelSchemasForTask.hasSchemasForLabel(label)) {
-                    Set<LabelSchema> labelSchemaSet = new HashSet<>();
-                    for (FileSpecificLabelSchema fileSpecificLabelSchema :
-                            fileSpecificLabelSchemasForTask.fileSpecificLabelSchemasFor(label)) {
-                        fileSpecificLabelSchemas.add(fileSpecificLabelSchema);
-                        labelSchemaSet.add(fileSpecificLabelSchema.labelSchema());
-                    }
-                    for (LabelSchema labelSchema : labelSchemaSet) {
-                        masterLabelSchema = masterLabelSchema.union(labelSchema);
-                    }
-                }
-            }
-
-            masterLabelSchemas.put(
-                    label,
-                    new MasterLabelSchema(masterLabelSchema, fileSpecificLabelSchemas));
-
-
-        }
-
-        return new MasterLabelSchemas(masterLabelSchemas, graphElementType);
+        return new MasterLabelSchemas(fileSpecificLabelSchemasCollection, graphElementType);
     }
 
     public Collection<ExportSpecification> splitByLabel() {

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementType.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/GraphElementType.java
@@ -19,12 +19,15 @@ import com.amazonaws.services.neptune.propertygraph.GraphClient;
 import com.amazonaws.services.neptune.propertygraph.NodesClient;
 import com.amazonaws.services.neptune.propertygraph.io.EdgesWriterFactory;
 import com.amazonaws.services.neptune.propertygraph.io.NodesWriterFactory;
+import com.amazonaws.services.neptune.propertygraph.io.QueriesWriterFactory;
 import com.amazonaws.services.neptune.propertygraph.io.WriterFactory;
 import com.amazonaws.services.neptune.propertygraph.io.result.PGResult;
+import com.amazonaws.services.neptune.util.NotImplementedException;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversalSource;
 
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
 public enum GraphElementType {
 
@@ -58,6 +61,22 @@ public enum GraphElementType {
         @Override
         public WriterFactory<? extends PGResult> writerFactory() {
             return new EdgesWriterFactory();
+        }
+    },
+    queryResults {
+        @Override
+        public Collection<String> tokenNames() {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public GraphClient<? extends PGResult> graphClient(GraphTraversalSource g, boolean tokensOnly, ExportStats stats, FeatureToggles featureToggles) {
+            throw new NotImplementedException();
+        }
+
+        @Override
+        public WriterFactory writerFactory() {
+            return new QueriesWriterFactory();
         }
     };
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/MasterLabelSchemas.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/MasterLabelSchemas.java
@@ -14,8 +14,12 @@ package com.amazonaws.services.neptune.propertygraph.schema;
 
 import com.amazonaws.services.neptune.propertygraph.Label;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 
 public class MasterLabelSchemas {
 
@@ -25,6 +29,10 @@ public class MasterLabelSchemas {
     public MasterLabelSchemas(Map<Label, MasterLabelSchema> masterLabelSchemas, GraphElementType graphElementType) {
         this.masterLabelSchemas = masterLabelSchemas;
         this.graphElementType = graphElementType;
+    }
+
+    public MasterLabelSchemas(Collection<FileSpecificLabelSchemas> fileSpecificLabelSchemasCollection, GraphElementType graphElementType) {
+        this(convertFileSpecificLabelSchemas(fileSpecificLabelSchemasCollection), graphElementType);
     }
 
     public Collection<MasterLabelSchema> schemas() {
@@ -41,5 +49,38 @@ public class MasterLabelSchemas {
             graphElementSchemas.addLabelSchema(masterLabelSchema.labelSchema(), masterLabelSchema.outputIds());
         }
         return graphElementSchemas;
+    }
+
+    private static Map<Label, MasterLabelSchema> convertFileSpecificLabelSchemas(Collection<FileSpecificLabelSchemas> fileSpecificLabelSchemasCollection) {
+        Set<Label> labels = new HashSet<>();
+
+        fileSpecificLabelSchemasCollection.forEach(s -> labels.addAll(s.labels()));
+
+        Map<Label, MasterLabelSchema> masterLabelSchemas = new HashMap<>();
+
+        for (Label label : labels) {
+
+            LabelSchema masterLabelSchema = new LabelSchema(label);
+            Collection<FileSpecificLabelSchema> fileSpecificLabelSchemas = new ArrayList<>();
+
+            for (FileSpecificLabelSchemas fileSpecificLabelSchemasForTask : fileSpecificLabelSchemasCollection) {
+                if (fileSpecificLabelSchemasForTask.hasSchemasForLabel(label)) {
+                    Set<LabelSchema> labelSchemaSet = new HashSet<>();
+                    for (FileSpecificLabelSchema fileSpecificLabelSchema :
+                            fileSpecificLabelSchemasForTask.fileSpecificLabelSchemasFor(label)) {
+                        fileSpecificLabelSchemas.add(fileSpecificLabelSchema);
+                        labelSchemaSet.add(fileSpecificLabelSchema.labelSchema());
+                    }
+                    for (LabelSchema labelSchema : labelSchemaSet) {
+                        masterLabelSchema = masterLabelSchema.union(labelSchema);
+                    }
+                }
+            }
+
+            masterLabelSchemas.put(
+                    label,
+                    new MasterLabelSchema(masterLabelSchema, fileSpecificLabelSchemas));
+        }
+        return masterLabelSchemas;
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
@@ -36,10 +36,24 @@ public class ExportPgFromQueriesIntegrationTest extends AbstractExportIntegratio
     }
 
     @Test
+    public void testExportPgFromQueriesNoHeaders() {
+        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
+                "-d", outputDir.getPath(), "--format", "csvNoHeaders",
+                "-q", "airport=g.V().hasLabel('airport').has('runways', gt(2)).project('code', 'runways', 'city', 'country').by('code').by('runways').by('city').by('country')"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders"), resultDir);
+    }
+
+    @Test
     public void testExportPgFromQueriesWithStaggeredResults() {
         final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
                 "-d", outputDir.getPath(),
-                "-q", "airport=g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])"
+                "-q", "airport=g.inject(['code': 'YYC'], ['city': 'Vancouver', 'code': 'YVR'], ['code':'SEA', 'city':'Seattle', 'runways': 3])"
         };
         final NeptuneExportRunner runner = new NeptuneExportRunner(command);
         runner.run();
@@ -61,20 +75,6 @@ public class ExportPgFromQueriesIntegrationTest extends AbstractExportIntegratio
         final File resultDir = outputDir.listFiles()[0];
 
         assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders"), resultDir);
-    }
-
-    @Test
-    public void testExportPgFromQueriesNoHeaders() {
-        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
-                "-d", outputDir.getPath(), "--format", "csvNoHeaders",
-                "-q", "airport=g.V().hasLabel('airport').has('runways', gt(2)).project('code', 'runways', 'city', 'country').by('code').by('runways').by('city').by('country')"
-        };
-        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
-        runner.run();
-
-        final File resultDir = outputDir.listFiles()[0];
-
-        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders"), resultDir);
     }
 
     @Test

--- a/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportPgFromQueriesIntegrationTest.java
@@ -36,6 +36,48 @@ public class ExportPgFromQueriesIntegrationTest extends AbstractExportIntegratio
     }
 
     @Test
+    public void testExportPgFromQueriesWithStaggeredResults() {
+        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
+                "-d", outputDir.getPath(),
+                "-q", "airport=g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults"), resultDir);
+    }
+
+    @Test
+    public void testExportPgFromQueriesWithStaggeredResultsNoHeaders() {
+        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
+                "-d", outputDir.getPath(), "--format", "csvNoHeaders",
+                "-q", "airport=g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders"), resultDir);
+    }
+
+    @Test
+    public void testExportPgFromQueriesNoHeaders() {
+        final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
+                "-d", outputDir.getPath(), "--format", "csvNoHeaders",
+                "-q", "airport=g.V().hasLabel('airport').has('runways', gt(2)).project('code', 'runways', 'city', 'country').by('code').by('runways').by('city').by('country')"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+
+        final File resultDir = outputDir.listFiles()[0];
+
+        assertEquivalentResults(new File("src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders"), resultDir);
+    }
+
+    @Test
     public void testExportPgFromQueriesSplitQueries() {
         final String[] command = {"export-pg-from-queries", "-e", neptuneEndpoint,
                 "-d", outputDir.getPath(),

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders/queries.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders/queries.json
@@ -1,0 +1,4 @@
+[ {
+  "name" : "airport",
+  "queries" : [ "g.V().hasLabel('airport').has('runways', gt(2)).project('code', 'runways', 'city', 'country').by('code').by('runways').by('city').by('country')" ]
+} ]

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders/results/airport/airport-1.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesNoHeaders/results/airport/airport-1.csv
@@ -1,4 +1,3 @@
-code,runways,city,country
 "ANC",3,"Anchorage","US"
 "BWI",3,"Baltimore","US"
 "DCA",3,"Washington D.C.","US"

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/queries.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/queries.json
@@ -1,4 +1,4 @@
 [ {
   "name" : "airport",
-  "queries" : [ "g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])" ]
+  "queries" : [ "g.inject(['code': 'YYC'], ['city': 'Vancouver', 'code': 'YVR'], ['code':'SEA', 'city':'Seattle', 'runways': 3])" ]
 } ]

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/queries.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/queries.json
@@ -1,0 +1,4 @@
+[ {
+  "name" : "airport",
+  "queries" : [ "g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])" ]
+} ]

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/results/airport/airport-1.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/results/airport/airport-1.csv
@@ -1,4 +1,4 @@
 code,city,runways
-"SEA","Seattle",3
-"YVR","Vancouver",
 "YYC",,
+"YVR","Vancouver",
+"SEA","Seattle",3

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/results/airport/airport-1.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResults/results/airport/airport-1.csv
@@ -1,0 +1,4 @@
+code,city,runways
+"SEA","Seattle",3
+"YVR","Vancouver",
+"YYC",,

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders/queries.json
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders/queries.json
@@ -1,0 +1,4 @@
+[ {
+  "name" : "airport",
+  "queries" : [ "g.inject(['code':'SEA', 'city':'Seattle', 'runways': 3], ['city': 'Vancouver', 'code': 'YVR'], ['code': 'YYC'])" ]
+} ]

--- a/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders/results/airport/airport-1.csv
+++ b/src/test/resources/IntegrationTest/testExportPgFromQueriesWithStaggeredResultsNoHeaders/results/airport/airport-1.csv
@@ -1,0 +1,3 @@
+"SEA","Seattle",3
+"YVR","Vancouver",
+"YYC",,


### PR DESCRIPTION
Issue #, if available:

Background:

Headers have historically always been missing in `export-pg-from-queries` jobs. The underlying reason for this is that schema inference has always technically been enabled for queries exports, however queries exports lacked the ability to accumulate a schema as results come in.

When schema inference is enabled, Neptune Export will stream results as they come in to an interim csv file, while also updating an internal schema which describes all of the data seen so far. Once all of the results have been received, a rewrite process is triggered which reads in the interim CSV files, and rewrites them to conform to the discovered schema. The interim csv files have no headers (as they are irrelevant without a complete schema), and may have some inconsistencies such as later rows having more columns than previous rows. These issues are corrected during the rewrite process.

The issue with `export-pg-from-queries` was that it was streaming results to interim csv files as expected, but the rewrite process was effectively a no-op as there was no accumulated schema to drive the re-write. In current versions of Neptune Export, the final csv files output from `export-pg-from-queries` are the pre-rewrite interim csv files without any headers or guaranteed column alignment.

Description of changes: 

This PR addresses the above issues by creating a new GraphElementType.queryResults and properly tracking queries stats in a new FileSpecificLabelSchema for these queriesResults. These schemas use the name of each named query in the export job in place of the Label from PG results. This is aligned to how output files are named and formatted.

With the proper tracking of schemas for queriesResults, the rewrite process now functions correctly which results in a header being included when expected and any inconsistencies in the interim csv due to "staggered" results being corrected.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

