### PR TITLE
Add retries to AddCloneTask.createInstance()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Bug Fixes:
 
+- Add retries to Neptune clone creation
+
 ## Neptune Export v1.1.11 (Release Date: Mar 10, 2025):
 
 ### Bug Fixes:

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -13,9 +13,12 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.cluster;
 
 
+import com.amazonaws.services.neptune.io.KinesisConfig;
 import com.amazonaws.services.neptune.util.Activity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.SdkRequest;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.neptune.model.*;
@@ -39,6 +42,7 @@ public class AddCloneTask {
     private final Supplier<NeptuneClient> amazonNeptuneClientSupplier;
     private final String cloneCorrelationId;
     private final boolean enableAuditLogs;
+    private static final Logger logger = LoggerFactory.getLogger(AddCloneTask.class);
 
     public AddCloneTask(String sourceClusterId,
                         String targetClusterId,
@@ -378,7 +382,44 @@ public class AddCloneTask {
             requestBuilder = requestBuilder.engineVersion(engineVersion);
         }
 
-        DBInstance targetDbInstance = neptune.createDBInstance(requestBuilder.build()).dbInstance();
+        // Retry configuration
+        int maxRetries = 3;
+        long initialBackoffMillis = 1000; // 1 second
+        DBInstance targetDbInstance = null;
+        CreateDbInstanceRequest request = requestBuilder.build();
+        
+        // Retry loop with exponential backoff
+        for (int attempt = 0; attempt <= maxRetries; attempt++) {
+            try {
+                targetDbInstance = neptune.createDBInstance(request).dbInstance();
+                // If we get here, the request was successful
+                break;
+            } catch (NeptuneException e) {
+                // Check if we've exhausted our retries
+                if (attempt == maxRetries) {
+                    logger.error("Failed to create {} instance after {} attempts", name, maxRetries);
+                    throw e;
+                }
+                
+                // Calculate backoff time with exponential increase and some jitter
+                long backoffMillis = initialBackoffMillis * (long) Math.pow(2, attempt);
+                long jitterMillis = (long) (backoffMillis * 0.2 * Math.random()); // 20% jitter
+                long totalBackoffMillis = backoffMillis + jitterMillis;
+
+                logger.debug("Failed to create {} instance (attempt {} of {}): {}. Retrying...", name, attempt + 1, maxRetries, e.getMessage());
+                
+                try {
+                    Thread.sleep(totalBackoffMillis);
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Instance creation interrupted", ie);
+                }
+            }
+        }
+        
+        if (targetDbInstance == null) {
+            throw new RuntimeException("Failed to create DB instance after exhausting all retries");
+        }
 
         String instanceStatus = targetDbInstance.dbInstanceStatus();
 

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -397,9 +397,11 @@ public class AddCloneTask {
             } catch (NeptuneException e) {
                 // Check if we've exhausted our retries
                 if (attempt == maxRetries) {
-                    logger.error("Failed to create {} instance after {} attempts", name, maxRetries);
-                    throw e;
+                    logger.error("Failed to create {} instance after {} attempts, with error {}", name, maxRetries, e.getMessage());
+                    return;
                 }
+
+
                 
                 // Calculate backoff time with exponential increase and some jitter
                 long backoffMillis = initialBackoffMillis * (long) Math.pow(2, attempt);
@@ -418,7 +420,8 @@ public class AddCloneTask {
         }
         
         if (targetDbInstance == null) {
-            throw new RuntimeException("Failed to create DB instance after exhausting all retries");
+            logger.warn("Failed to create DB instance {} after exhausting all retries", name);
+            return;
         }
 
         String instanceStatus = targetDbInstance.dbInstanceStatus();

--- a/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/CloneCluster.java
@@ -77,7 +77,7 @@ public class CloneCluster implements CloneClusterStrategy {
         InstanceType instanceType =  InstanceType.parse(
                 targetClusterMetadata.instanceMetadataFor(targetClusterMetadata.primary()).instanceType());
 
-        int targetConcurrency = instanceType.concurrency() * (1 + replicaCount);
+        int targetConcurrency = instanceType.concurrency() * (1 + targetClusterMetadata.replicas().size());
         int newConcurrency = maxConcurrency > 0 ?
                 Math.min(maxConcurrency, targetConcurrency) :
                 targetConcurrency;

--- a/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
@@ -32,11 +32,13 @@ import software.amazon.awssdk.services.neptune.model.DescribeDbClusterParameters
 import software.amazon.awssdk.services.neptune.model.DescribeDbParametersRequest;
 import software.amazon.awssdk.services.neptune.model.DescribeDbParametersResponse;
 import software.amazon.awssdk.services.neptune.model.ModifyDbClusterParameterGroupRequest;
+import software.amazon.awssdk.services.neptune.model.NeptuneException;
 import software.amazon.awssdk.services.neptune.model.Parameter;
 import software.amazon.awssdk.services.neptune.model.RestoreDbClusterToPointInTimeRequest;
 import software.amazon.awssdk.services.neptune.model.RestoreDbClusterToPointInTimeResponse;
 
 import java.util.Arrays;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -107,6 +109,35 @@ public class AddCloneTaskTest {
 
         // Assert that cluster audit log exports are enabled
         assertEquals(Arrays.asList("audit"), capturedCloneRequest.enableCloudwatchLogsExports());
+    }
+
+    @Test
+    public void shouldRetryIfCreateInstanceFails() {
+        NeptuneClient mockNeptune = createMockNeptune();
+
+        AddCloneTask addCloneTask = new AddCloneTask("sourceClusterId", "targetClusterId", "db_r5_large", 3, null,
+                () -> mockNeptune, null, false);
+
+        final AtomicInteger invocations = new AtomicInteger(0);
+
+        when(mockNeptune.createDBInstance((CreateDbInstanceRequest) any())).thenAnswer(invocation -> {
+            if (invocations.incrementAndGet() <= 2 || invocations.get() == 4) {
+                throw NeptuneException.builder().message("Test Exception").build();
+            }
+            CreateDbInstanceResponse mockCreateInstanceResponse = mock(CreateDbInstanceResponse.class);
+            DBInstance targetDbInstance = DBInstance.builder().dbInstanceStatus("available").build();
+            when(mockCreateInstanceResponse.dbInstance()).thenReturn(targetDbInstance);
+
+            return mockCreateInstanceResponse;
+        });
+
+        // Mock static method to skip creating NeptuneClusterMetadata for test
+        try (MockedStatic<NeptuneClusterMetadata> classMock = mockStatic(NeptuneClusterMetadata.class)) {
+            classMock.when(() -> NeptuneClusterMetadata.createFromClusterId(any(), any())).thenReturn(mock(NeptuneClusterMetadata.class));
+            addCloneTask.execute();
+        }
+
+        assertEquals("Expected 7 invocations to createDBInstance(), 3 failing, 1 primary, and 3 replicas",7, invocations.get());
     }
 
     private NeptuneClient createMockNeptune() {


### PR DESCRIPTION
Issue #, if available:

Description of changes:

Adds retries with exponential backoff when adding instances to clones. In cases with a very high replication count, instance creation can sometimes fail which is mitigated by retries.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

