### PR TITLE
Fix silent failure in uploadExportFilesToS3

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -363,9 +363,17 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
                     CompletedDirectoryUpload completedDirectoryUpload = upload.completionFuture().join();
                     List<FailedFileUpload> failedFileUploads = completedDirectoryUpload.failedTransfers();
 
+                    RuntimeException fileUploadException = null;
                     for (FailedFileUpload failedFileUpload : failedFileUploads) {
                         logger.error("Failed S3 upload for file {}", failedFileUpload.request().source(), failedFileUpload.exception());
-                        throw new RuntimeException(failedFileUpload.exception());
+                        if (fileUploadException == null) {
+                            fileUploadException = new RuntimeException(failedFileUpload.exception());
+                        } else {
+                            fileUploadException.addSuppressed(failedFileUpload.exception());
+                        }
+                    }
+                    if (fileUploadException != null) {
+                        throw fileUploadException;
                     }
                 } catch (CompletionException e) {
                     if (e.getCause() instanceof AmazonServiceException) {

--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -24,13 +24,13 @@ import com.amazonaws.services.neptune.util.Timer;
 import com.amazonaws.services.neptune.util.TransferManagerWrapper;
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.ServerSideEncryption;
 import software.amazon.awssdk.services.s3.model.Tag;
 import software.amazon.awssdk.services.s3.model.Tagging;
 import software.amazon.awssdk.transfer.s3.S3TransferManager;
+import software.amazon.awssdk.transfer.s3.model.CompletedDirectoryUpload;
 import software.amazon.awssdk.transfer.s3.model.DirectoryUpload;
+import software.amazon.awssdk.transfer.s3.model.FailedFileUpload;
 import software.amazon.awssdk.transfer.s3.model.FileUpload;
-import software.amazon.awssdk.transfer.s3.model.Upload;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
@@ -343,25 +343,29 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
 
         while (allowRetry){
             try {
-                PutObjectRequest putObjectRequest = configureServerSideEncryption(PutObjectRequest.builder(), sseKmsKeyId)
-                        .tagging(createObjectTags(profiles))
-                        .build();
-
                 logger.info("Uploading export files to {}", outputS3ObjectInfo.toString());
 
                 UploadDirectoryRequest uploadRequest = UploadDirectoryRequest.builder()
                         .source(directory.toPath())
                         .bucket(outputS3ObjectInfo.bucket())
                         .s3Prefix(outputS3ObjectInfo.key())
-                        .uploadFileRequestTransformer((uploadFileRequestBuilder) -> {
-                            uploadFileRequestBuilder.putObjectRequest(putObjectRequest);
+                        .uploadFileRequestTransformer(builder -> {
+                            UploadFileRequest built = builder.build();
+                            PutObjectRequest.Builder newBuilder = built.putObjectRequest().toBuilder();
+                                newBuilder = configureServerSideEncryption(newBuilder, sseKmsKeyId).tagging(createObjectTags(profiles));
+                                builder.putObjectRequest(newBuilder.build());
                         })
                         .build();
 
                 try{
                     DirectoryUpload upload = transferManager.uploadDirectory(uploadRequest);
 
-                    upload.completionFuture().join();
+                    CompletedDirectoryUpload completedDirectoryUpload = upload.completionFuture().join();
+                    List<FailedFileUpload> failedFileUploads = completedDirectoryUpload.failedTransfers();
+
+                    for (FailedFileUpload failedFileUpload : failedFileUploads) {
+                        logger.error("Failed to upload file to S3", failedFileUpload.exception());
+                    }
                 } catch (CompletionException e) {
                     if (e.getCause() instanceof AmazonServiceException) {
                         AmazonClientException amazonClientException = (AmazonClientException) e.getCause();

--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -365,6 +365,7 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
 
                     for (FailedFileUpload failedFileUpload : failedFileUploads) {
                         logger.error("Failed S3 upload for file {}", failedFileUpload.request().source(), failedFileUpload.exception());
+                        throw new RuntimeException(failedFileUpload.exception());
                     }
                 } catch (CompletionException e) {
                     if (e.getCause() instanceof AmazonServiceException) {

--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -364,7 +364,7 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
                     List<FailedFileUpload> failedFileUploads = completedDirectoryUpload.failedTransfers();
 
                     for (FailedFileUpload failedFileUpload : failedFileUploads) {
-                        logger.error("Failed to upload file to S3", failedFileUpload.exception());
+                        logger.error("Failed S3 upload for file {}", failedFileUpload.request().source(), failedFileUpload.exception());
                     }
                 } catch (CompletionException e) {
                     if (e.getCause() instanceof AmazonServiceException) {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

The recent (currently unreleased) upgrade to AWS SDK v2 introduced a silent failure in the upload of export files to S3. With the new S3 API, there is very little customization that can be done directly on an `UploadDirectoryRequest.Builder`, instead, many configurations such as adding tags must be done via an `UploadFileRequestTransformer`, which allows for mutation of the individual file upload requests which ultimately get generated.

The bug here is that by attempting to directly update `putObjectRequest()` on the `UploadFileRequest.Builder`, the effect is to null all existing non-overridden parameters in the `PutObjectRequest`. This includes essential parameters such as `bucket` and `key`. The end result is an upload which is guaranteed to fail. The solution here is to clone the original `PutObjectRequest` and create a new builder from it, which then allows customization of the necessary parameters and attachment back to the original `UploadFileRequest` builder.

The original code here used to fail silently as a `DirectoryUpload` will not fail exceptionally if one or more (or all) underlying FileUploadRequests fail. The individual file upload failures were buried inside the `DirectoryUpload` and there was no indication of any issue other than the files ultimately being missing in S3. This PR also includes a change to log an error for each failed file upload to give proper visibility.

Testing:

Verified successful file upload and correct tagging for all code paths which upload files to S3 (Full directory upload, completion file upload, training config file upload for both V1 and V2 ML profiles, and GcLogFile for failed exports).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

