### PR TITLE
Use Neptune Export Service Job Id as default exportId if available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ### New Features and Improvements:
 
 - Migrate to AWS SDK for Java v2
+- Use the jobId from the Neptune Export Service (AWS Batch jobId) as the default exportId if available
 
 ### Bug Fixes:
 

--- a/src/main/java/com/amazonaws/services/neptune/cli/AbstractTargetModule.java
+++ b/src/main/java/com/amazonaws/services/neptune/cli/AbstractTargetModule.java
@@ -82,7 +82,7 @@ public abstract class AbstractTargetModule implements CommandWriter {
 
     @Option(name = {"--export-id"}, description = "Export ID")
     @Once
-    private String exportId = UUID.randomUUID().toString().replace("-", "");
+    private String exportId = getDefaultExportId();
 
     @Option(name = {"--partition-directories"}, description = "Partition directory path (e.g. 'year=2021/month=07/day=21').")
     @Once
@@ -146,6 +146,24 @@ public abstract class AbstractTargetModule implements CommandWriter {
             return credentialProfileModule.getCredentialsProvider();
         }
         return getSTSAssumeRoleCredentialsProvider(streamRoleArn, streamRoleSessionName, streamRoleExternalId, credentialProfileModule.getCredentialsProvider(), region);
+    }
+
+    /**
+     * Use AWS Batch JobID as export id if available, otherwise use a random UUID
+     * @return
+     */
+    private static String getDefaultExportId() {
+        String id = null;
+        try {
+            id = System.getenv("AWS_BATCH_JOB_ID"); // Use AWS Batch job id if running in Neptune Export Service
+        }
+        catch (SecurityException e) {
+            // Do nothing, will generate new ID if targetClusterIdSuffix is not set.
+        }
+        if (StringUtils.isEmpty(id)) {
+            id = UUID.randomUUID().toString();
+        }
+        return id.replace("-", "");
     }
 
 }


### PR DESCRIPTION
Description of changes:

Updates the default export ID to look for an AWS Batch job id in the environment. If found, it will be used, otherwise a random UUID is generated. When running Neptune Export via the export service stack, the Batch ID in the environment matches the service Job Id. This is the same mechanism currently used to name Neptune cluster clones.

Testing:

I have tested the changes in a test deployment of the Neptune Export service stack. I've verified that the jobId is correctly propagated all the way to the S3 upload by default, and that a custom export id is propagated all the way to S3 if it is explicitly overridden by the export params.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

