### PR TITLE
Disable DFE for Gremlin queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 
 - Add retries to Neptune clone creation
 - Fix missing csv headers from `export-pg-from-queries`
+- Disable DFE for all Gremlin queries
 
 ## Neptune Export v1.1.11 (Release Date: Mar 10, 2025):
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/NeptuneGremlinClient.java
@@ -93,7 +93,7 @@ public class NeptuneGremlinClient implements AutoCloseable {
     }
 
     public GraphTraversalSource newTraversalSource() {
-        return AnonymousTraversalSource.traversal().withRemote(DriverRemoteConnection.using(cluster));
+        return AnonymousTraversalSource.traversal().withRemote(DriverRemoteConnection.using(cluster)).withSideEffect("Neptune#useDFE", false);
     }
 
     public QueryClient queryClient() {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

DFE is not supported by Neptune Export for gremlin queries as it does not produce results in a consistent order, which is required to split queries with the range() step. This PR adds a query hint such that DFE will not be used, even if it is enabled by default in the cluster parameters.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

