### PR TITLE
Enable multipart s3 uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+- Fix inability to upload large files (>5GB) to S3
+
 ## Neptune Export v2.0.0 (Release Date: May 15, 2025):
 
 ### Breaking Changes:

--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,12 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>aws-crt-client</artifactId>
+            <version>${aws.sdk.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>com.github.stefanbirkner</groupId>
             <artifactId>system-rules</artifactId>
             <version>1.19.0</version>

--- a/src/main/java/com/amazonaws/services/neptune/util/TransferManagerWrapper.java
+++ b/src/main/java/com/amazonaws/services/neptune/util/TransferManagerWrapper.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.util;
 
 import software.amazon.awssdk.auth.credentials.AwsCredentialsProvider;
+import software.amazon.awssdk.http.crt.AwsCrtAsyncHttpClient;
 import software.amazon.awssdk.regions.Region;
 import software.amazon.awssdk.services.s3.S3AsyncClient;
 import software.amazon.awssdk.services.s3.S3AsyncClientBuilder;
@@ -29,7 +30,9 @@ public class TransferManagerWrapper implements AutoCloseable {
 
     public TransferManagerWrapper(String s3Region, AwsCredentialsProvider credentialsProvider) {
 
-        S3AsyncClientBuilder amazonS3ClientBuilder = S3AsyncClient.builder();
+        S3AsyncClientBuilder amazonS3ClientBuilder = S3AsyncClient.builder()
+                .httpClient(AwsCrtAsyncHttpClient.builder().build())
+                .multipartEnabled(true);
         if (credentialsProvider != null) {
             amazonS3ClientBuilder = amazonS3ClientBuilder.credentialsProvider(credentialsProvider);
         }


### PR DESCRIPTION
Issue #, if available:

Description of changes:

There was a regression in the recent release of Neptune Export v2.0.0 resulting from the migration to AWS SDK for Java v2. One of the impacts of the migration is that the updated S3TransferManager does not have multipart S3 uploads enabled by default. Lack of multipart uploads limits throughput for large uploads and more significantly results in a 5GB size limit for individual files. Files exceeding 5GB in size are rare for most usages of Neptune Export as the files are divided for each unique label and thread, however for very large exports this limit can present issues.

This PR switches the internal HTTP client from the default `NettyNioAsyncHttpClient` to `AwsCrtAsyncHttpClient`, which supports multipart uploads, and adds the new configuration to turn on multipart uploads.

I have tested these changes with directory uploads in excess of 10GB, containing individual files in excess of 5GB.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.