### PR TITLE
Fix version-based fallback for finding param group family

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Bug Fixes:
 
+* Fix fallback for finding parameter group families via Neptune engine version
+
 ## Neptune Export v2.0.1 (Release Date: June 10, 2025):
 
 ### Bug Fixes:

--- a/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
@@ -12,6 +12,8 @@ permissions and limitations under the License.
 
 package com.amazonaws.services.neptune.cluster;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import com.amazonaws.services.neptune.export.EndpointValidator;
 import org.apache.commons.lang3.StringUtils;
@@ -25,6 +27,8 @@ public class NeptuneClusterMetadata {
 
     public static final String NEPTUNE_EXPORT_APPLICATION_TAG = "neptune-export";
     public static final String NEPTUNE_EXPORT_CORRELATION_ID_KEY = "correlation-id";
+
+    private static final Logger logger = LoggerFactory.getLogger(NeptuneClusterMetadata.class);
 
     public static String clusterIdFromEndpoint(String endpoint) {
         int index = endpoint.indexOf(".");
@@ -135,20 +139,23 @@ public class NeptuneClusterMetadata {
                     "neptune1";
 
         } catch (NeptuneException e) {
+            logger.warn("Failed to retrieve DB parameter group family: {}. Falling back to version-based detection.", e.getMessage());
 
             // Older deployments of Neptune Export service may not have requisite permissions to
             // describe cluster parameter group, so we'll try and guess the group family.
 
-
             if (StringUtils.isNotEmpty(engineVersion) && engineVersion.contains(".")) {
-                int v = Integer.parseInt(engineVersion.split("\\.")[1]);
-                if (v == 3) {
-                    dbParameterGroupFamily = "neptune1.3";
+                int major = Integer.parseInt(engineVersion.split("\\.")[0]);
+                int minor = Integer.parseInt(engineVersion.split("\\.")[1]);
+
+                if (major == 1 && minor <= 1) {
+                    dbParameterGroupFamily = "neptune1";
                 } else {
-                    dbParameterGroupFamily = v > 1 ? "neptune1.2" : "neptune1";
+                    dbParameterGroupFamily = String.format("neptune%s.%s", major, minor);
                 }
             } else {
-                dbParameterGroupFamily = "neptune1";
+                logger.error("Failed to determine correct DB Parameter group family from engine version");
+                throw e;
             }
         }
 
@@ -338,7 +345,7 @@ public class NeptuneClusterMetadata {
         System.err.println("Security group IDs      : " + String.join(", ", vpcSecurityGroupIds()));
         System.err.println("Instance endpoints      : " + String.join(", ", endpoints()));
 
-        NeptuneClusterMetadata.NeptuneInstanceMetadata primary = instanceMetadataFor(primary());
+        NeptuneInstanceMetadata primary = instanceMetadataFor(primary());
         System.err.println();
         System.err.println("Primary");
         System.err.println("  Instance ID              : " + primary());
@@ -348,7 +355,7 @@ public class NeptuneClusterMetadata {
 
         if (!replicas().isEmpty()) {
             for (String replicaId : replicas()) {
-                NeptuneClusterMetadata.NeptuneInstanceMetadata replica = instanceMetadataFor(replicaId);
+                NeptuneInstanceMetadata replica = instanceMetadataFor(replicaId);
                 System.err.println();
                 System.err.println("Replica");
                 System.err.println("  Instance ID              : " + replicaId);

--- a/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
@@ -21,6 +21,8 @@ import software.amazon.awssdk.services.neptune.model.*;
 
 import java.util.*;
 import java.util.function.Supplier;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class NeptuneClusterMetadata {
@@ -144,9 +146,12 @@ public class NeptuneClusterMetadata {
             // Older deployments of Neptune Export service may not have requisite permissions to
             // describe cluster parameter group, so we'll try and guess the group family.
 
-            if (StringUtils.isNotEmpty(engineVersion) && engineVersion.contains(".")) {
-                int major = Integer.parseInt(engineVersion.split("\\.")[0]);
-                int minor = Integer.parseInt(engineVersion.split("\\.")[1]);
+            Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)(\\.\\d+)*");
+            Matcher matcher = versionPattern.matcher(engineVersion != null ? engineVersion : "");
+
+            if (StringUtils.isNotEmpty(engineVersion) && matcher.find()) {
+                int major = Integer.parseInt(matcher.group(1));
+                int minor = Integer.parseInt(matcher.group(2));
 
                 if (major == 1 && minor <= 1) {
                     dbParameterGroupFamily = "neptune1";
@@ -154,7 +159,7 @@ public class NeptuneClusterMetadata {
                     dbParameterGroupFamily = String.format("neptune%s.%s", major, minor);
                 }
             } else {
-                logger.error("Failed to determine correct DB Parameter group family from engine version");
+                logger.error("Failed to determine correct DB Parameter group family from engine version [{}]", engineVersion);
                 throw e;
             }
         }

--- a/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadata.java
@@ -30,6 +30,9 @@ public class NeptuneClusterMetadata {
     public static final String NEPTUNE_EXPORT_APPLICATION_TAG = "neptune-export";
     public static final String NEPTUNE_EXPORT_CORRELATION_ID_KEY = "correlation-id";
 
+    private static final Pattern engineVersionPattern = Pattern.compile("^(\\d+)\\.(\\d+)(\\.\\d+)*");
+
+
     private static final Logger logger = LoggerFactory.getLogger(NeptuneClusterMetadata.class);
 
     public static String clusterIdFromEndpoint(String endpoint) {
@@ -146,8 +149,7 @@ public class NeptuneClusterMetadata {
             // Older deployments of Neptune Export service may not have requisite permissions to
             // describe cluster parameter group, so we'll try and guess the group family.
 
-            Pattern versionPattern = Pattern.compile("^(\\d+)\\.(\\d+)(\\.\\d+)*");
-            Matcher matcher = versionPattern.matcher(engineVersion != null ? engineVersion : "");
+            Matcher matcher = engineVersionPattern.matcher(engineVersion != null ? engineVersion : "");
 
             if (StringUtils.isNotEmpty(engineVersion) && matcher.find()) {
                 int major = Integer.parseInt(matcher.group(1));

--- a/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
@@ -12,62 +12,109 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.cluster;
 
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
-import org.mockito.Mockito;
 import software.amazon.awssdk.services.neptune.NeptuneClient;
 import software.amazon.awssdk.services.neptune.model.*;
 
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
-import java.util.function.Supplier;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@RunWith(Parameterized.class)
+@RunWith(Enclosed.class)
 public class NeptuneClusterMetadataTest {
 
-    @Parameterized.Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-        return Arrays.asList(new Object[][] {
-                { "1.0.5.0", "neptune1" },
-                { "1.1.0.0", "neptune1" },
-                { "1.1.1.0", "neptune1" },
-                { "1.2.0.0", "neptune1.2" },
-                { "1.2.1.1", "neptune1.2" },
-                { "1.3.0.0", "neptune1.3" },
-                { "1.4.5.0", "neptune1.4" },
-                { "1.5.6.7", "neptune1.5" },
-                { "2.0.0.0", "neptune2.0" },
-                { "12.24.48.64", "neptune12.24" }
-        });
+    @RunWith(Parameterized.class)
+    public static class SuccessfulCases {
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    {"1.0.5.0", "neptune1"},
+                    {"1.1.0.0", "neptune1"},
+                    {"1.1.1.0", "neptune1"},
+                    {"1.2.0.0", "neptune1.2"},
+                    {"1.2.1.1", "neptune1.2"},
+                    {"1.3.0.0", "neptune1.3"},
+                    {"1.4.5.0", "neptune1.4"},
+                    {"1.5.6.7", "neptune1.5"},
+                    {"2.0.0.0", "neptune2.0"},
+                    {"12.24.48.64", "neptune12.24"}
+            });
+        }
+
+        @Parameterized.Parameter(0)
+        public static String engineVersion;
+        @Parameterized.Parameter(1)
+        public static String expectedParameterGroupFamily;
+
+        @Test
+        public void shouldExtractParamGroupFamilyFromSDKWhenPossible() {
+            NeptuneClient mockNeptuneClient = createMockNeptuneClient("engineVersion");
+
+            DBClusterParameterGroup parameterGroup = DBClusterParameterGroup.builder()
+                .dbParameterGroupFamily(expectedParameterGroupFamily)
+                .dbClusterParameterGroupName("default."+expectedParameterGroupFamily)
+                .build();
+
+            when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
+                    .thenReturn(DescribeDbClusterParameterGroupsResponse.builder()
+                            .dbClusterParameterGroups(Collections.singletonList(parameterGroup))
+                            .build());
+            // Verify the parameter group family is correctly determined
+            assertEquals(expectedParameterGroupFamily, NeptuneClusterMetadata.createFromClusterId("test", () -> mockNeptuneClient).dbParameterGroupFamily());
+        }
+
+        @Test
+        public void shouldUseVersionBasedFallbackForParamGroupFamily() {
+            NeptuneClient mockNeptuneClient = createMockNeptuneClient(engineVersion);
+
+            // Mock the describeDBClusterParameterGroups to throw NeptuneException
+            when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
+                    .thenThrow(NeptuneException.builder().message("Access Denied").build());
+            // Verify the parameter group family is correctly determined from the engine version
+            assertEquals(expectedParameterGroupFamily, NeptuneClusterMetadata.createFromClusterId("test", () -> mockNeptuneClient).dbParameterGroupFamily());
+        }
     }
 
-    private final String engineVersion;
-    private final String expectedParameterGroupFamily;
+    @RunWith(Parameterized.class)
+    public static class FailingCases {
+        @Parameterized.Parameters(name = "{0}")
+        public static Collection<String> data() {
+            return Arrays.asList("Non-Parseable Engine Version", null, "1234", "");
+        }
 
-    public NeptuneClusterMetadataTest(String engineVersion, String expectedParameterGroupFamily) {
-        this.engineVersion = engineVersion;
-        this.expectedParameterGroupFamily = expectedParameterGroupFamily;
+        @Parameterized.Parameter
+        public static String engineVersion;
+
+        @Test
+        public void shouldRethrowExceptionIfFallbackForParamGroupFamilyFails() {
+            // This test is not parameterized, so we use a fixed non-parseable engine version
+            NeptuneClient mockNeptuneClient = createMockNeptuneClient(engineVersion);
+
+            Exception expectedException = NeptuneException.builder().message("Access Denied").build();
+
+            // Mock the describeDBClusterParameterGroups to throw NeptuneException
+            when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
+                    .thenThrow(expectedException);
+
+            try {
+                NeptuneClusterMetadata.createFromClusterId("test", () -> mockNeptuneClient).dbParameterGroupFamily();
+                fail("Expected NeptuneException to be thrown");
+            } catch (Exception caughtException) {
+                assertEquals(expectedException, caughtException);
+            }
+        }
     }
 
-    @Test
-    public void shouldUseVersionBasedFallbackForParamGroupFamily() {
-        // Setup mock NeptuneClient
-        NeptuneClient mockNeptuneClient = Mockito.mock(NeptuneClient.class);
-        
-       setupMocks();
-        // Mock the describeDBClusterParameterGroups to throw NeptuneException
-        when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
-                .thenThrow(NeptuneException.builder().message("Access Denied").build());
-        // Verify the parameter group family is correctly determined from the engine version
-        assertEquals(expectedParameterGroupFamily, NeptuneClusterMetadata.createFromClusterId("test", () -> mockNeptuneClient).dbParameterGroupFamily());
-    }
-
-    private void setupMocks() {
+    protected static NeptuneClient createMockNeptuneClient(String engineVersion) {
+        NeptuneClient mockNeptuneClient = mock(NeptuneClient.class);
         when(mockNeptuneClient.describeDBClusters(any(DescribeDbClustersRequest.class)))
                 .thenReturn(DescribeDbClustersResponse.builder()
                         .dbClusters(Collections.singletonList(DBCluster.builder()
@@ -115,5 +162,6 @@ public class NeptuneClusterMetadataTest {
                                         .build())
                                 .build()))
                         .build());
+        return mockNeptuneClient;
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
@@ -59,85 +59,61 @@ public class NeptuneClusterMetadataTest {
         // Setup mock NeptuneClient
         NeptuneClient mockNeptuneClient = Mockito.mock(NeptuneClient.class);
         
-        // Mock the describeDBClusters response
-        DBCluster mockDbCluster = DBCluster.builder()
-                .dbClusterIdentifier("test")
-                .dbClusterArn("arn:aws:rds:us-east-1:123456789012:cluster:test")
-                .dbClusterParameterGroup("default.neptune1")
-                .engineVersion(engineVersion)
-                .port(8182)
-                .iamDatabaseAuthenticationEnabled(false)
-                .dbClusterMembers(
-                        DBClusterMember.builder()
-                                .dbInstanceIdentifier("instance-1")
-                                .isClusterWriter(true)
-                                .build()
-                )
-                .build();
-        
-        DescribeDbClustersResponse mockDescribeDbClustersResponse = DescribeDbClustersResponse.builder()
-                .dbClusters(Collections.singletonList(mockDbCluster))
-                .build();
-        
-        when(mockNeptuneClient.describeDBClusters(any(DescribeDbClustersRequest.class)))
-                .thenReturn(mockDescribeDbClustersResponse);
-        
-        // Mock the listTagsForResource response
-        ListTagsForResourceResponse mockListTagsResponse = ListTagsForResourceResponse.builder()
-                .tagList(Collections.emptyList())
-                .build();
-
-        when(mockNeptuneClient.listTagsForResource(any(ListTagsForResourceRequest.class)))
-                .thenReturn(mockListTagsResponse);
-        
+       setupMocks();
         // Mock the describeDBClusterParameterGroups to throw NeptuneException
         when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
                 .thenThrow(NeptuneException.builder().message("Access Denied").build());
-        
-        // Mock the describeDBClusterParameters response
-        Parameter neptuneStreamsParameter = Parameter.builder()
-                .parameterName("neptune_streams")
-                .parameterValue("0")
-                .build();
+        // Verify the parameter group family is correctly determined from the engine version
+        assertEquals(expectedParameterGroupFamily, NeptuneClusterMetadata.createFromClusterId("test", () -> mockNeptuneClient).dbParameterGroupFamily());
+    }
 
-        DescribeDbClusterParametersResponse mockParametersResponse = DescribeDbClusterParametersResponse.builder()
-                .parameters(Collections.singletonList(neptuneStreamsParameter))
-                .build();
+    private void setupMocks() {
+        when(mockNeptuneClient.describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(DescribeDbClustersResponse.builder()
+                        .dbClusters(Collections.singletonList(DBCluster.builder()
+                                .dbClusterIdentifier("test")
+                                .dbClusterArn("arn:aws:rds:us-east-1:123456789012:cluster:test")
+                                .dbClusterParameterGroup("default.neptune1")
+                                .engineVersion(engineVersion)
+                                .port(8182)
+                                .iamDatabaseAuthenticationEnabled(false)
+                                .dbClusterMembers(
+                                        DBClusterMember.builder()
+                                                .dbInstanceIdentifier("instance-1")
+                                                .isClusterWriter(true)
+                                                .build()
+                                )
+                                .build()))
+                        .build());
+
+        when(mockNeptuneClient.listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(ListTagsForResourceResponse.builder()
+                        .tagList(Collections.emptyList())
+                        .build());
 
         when(mockNeptuneClient.describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class)))
-                .thenReturn(mockParametersResponse);
-        
-        // Mock the describeDBInstances response
-        Endpoint mockEndpoint = Endpoint.builder()
-                .address("instance-1.test.us-east-1.neptune.amazonaws.com")
-                .port(8182)
-                .build();
-
-        DBInstance mockDbInstance = DBInstance.builder()
-                .dbInstanceIdentifier("instance-1")
-                .dbInstanceClass("db.r5.large")
-                .dbParameterGroups(Collections.singletonList(
-                        DBParameterGroupStatus.builder()
-                                .dbParameterGroupName("default.neptune1")
-                                .build()
-                ))
-                .endpoint(mockEndpoint)
-                .build();
-
-        DescribeDbInstancesResponse mockDescribeDbInstancesResponse = DescribeDbInstancesResponse.builder()
-                .dbInstances(Collections.singletonList(mockDbInstance))
-                .build();
+                .thenReturn(DescribeDbClusterParametersResponse.builder()
+                        .parameters(Collections.singletonList(Parameter.builder()
+                                .parameterName("neptune_streams")
+                                .parameterValue("0")
+                                .build()))
+                        .build());
 
         when(mockNeptuneClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
-                .thenReturn(mockDescribeDbInstancesResponse);
-        
-        // Create supplier for mock NeptuneClient
-        Supplier<NeptuneClient> mockNeptuneClientSupplier = () -> mockNeptuneClient;
-        
-        // Call the method under test
-        NeptuneClusterMetadata clusterMetadata = NeptuneClusterMetadata.createFromClusterId("test", mockNeptuneClientSupplier);
-        
-        // Verify the parameter group family is correctly determined
-        assertEquals(expectedParameterGroupFamily, clusterMetadata.dbParameterGroupFamily());
+                .thenReturn(DescribeDbInstancesResponse.builder()
+                        .dbInstances(Collections.singletonList(DBInstance.builder()
+                                .dbInstanceIdentifier("instance-1")
+                                .dbInstanceClass("db.r5.large")
+                                .dbParameterGroups(Collections.singletonList(
+                                        DBParameterGroupStatus.builder()
+                                                .dbParameterGroupName("default.neptune1")
+                                                .build()
+                                ))
+                                .endpoint(Endpoint.builder()
+                                        .address("instance-1.test.us-east-1.neptune.amazonaws.com")
+                                        .port(8182)
+                                        .build())
+                                .build()))
+                        .build());
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
@@ -95,7 +95,6 @@ public class NeptuneClusterMetadataTest {
 
         @Test
         public void shouldRethrowExceptionIfFallbackForParamGroupFamilyFails() {
-            // This test is not parameterized, so we use a fixed non-parseable engine version
             NeptuneClient mockNeptuneClient = createMockNeptuneClient(engineVersion);
 
             Exception expectedException = NeptuneException.builder().message("Access Denied").build();

--- a/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/NeptuneClusterMetadataTest.java
@@ -1,0 +1,143 @@
+/*
+Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+package com.amazonaws.services.neptune.cluster;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.mockito.Mockito;
+import software.amazon.awssdk.services.neptune.NeptuneClient;
+import software.amazon.awssdk.services.neptune.model.*;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(Parameterized.class)
+public class NeptuneClusterMetadataTest {
+
+    @Parameterized.Parameters(name = "{0}")
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][] {
+                { "1.0.5.0", "neptune1" },
+                { "1.1.0.0", "neptune1" },
+                { "1.1.1.0", "neptune1" },
+                { "1.2.0.0", "neptune1.2" },
+                { "1.2.1.1", "neptune1.2" },
+                { "1.3.0.0", "neptune1.3" },
+                { "1.4.5.0", "neptune1.4" },
+                { "1.5.6.7", "neptune1.5" },
+                { "2.0.0.0", "neptune2.0" },
+                { "12.24.48.64", "neptune12.24" }
+        });
+    }
+
+    private final String engineVersion;
+    private final String expectedParameterGroupFamily;
+
+    public NeptuneClusterMetadataTest(String engineVersion, String expectedParameterGroupFamily) {
+        this.engineVersion = engineVersion;
+        this.expectedParameterGroupFamily = expectedParameterGroupFamily;
+    }
+
+    @Test
+    public void shouldUseVersionBasedFallbackForParamGroupFamily() {
+        // Setup mock NeptuneClient
+        NeptuneClient mockNeptuneClient = Mockito.mock(NeptuneClient.class);
+        
+        // Mock the describeDBClusters response
+        DBCluster mockDbCluster = DBCluster.builder()
+                .dbClusterIdentifier("test")
+                .dbClusterArn("arn:aws:rds:us-east-1:123456789012:cluster:test")
+                .dbClusterParameterGroup("default.neptune1")
+                .engineVersion(engineVersion)
+                .port(8182)
+                .iamDatabaseAuthenticationEnabled(false)
+                .dbClusterMembers(
+                        DBClusterMember.builder()
+                                .dbInstanceIdentifier("instance-1")
+                                .isClusterWriter(true)
+                                .build()
+                )
+                .build();
+        
+        DescribeDbClustersResponse mockDescribeDbClustersResponse = DescribeDbClustersResponse.builder()
+                .dbClusters(Collections.singletonList(mockDbCluster))
+                .build();
+        
+        when(mockNeptuneClient.describeDBClusters(any(DescribeDbClustersRequest.class)))
+                .thenReturn(mockDescribeDbClustersResponse);
+        
+        // Mock the listTagsForResource response
+        ListTagsForResourceResponse mockListTagsResponse = ListTagsForResourceResponse.builder()
+                .tagList(Collections.emptyList())
+                .build();
+
+        when(mockNeptuneClient.listTagsForResource(any(ListTagsForResourceRequest.class)))
+                .thenReturn(mockListTagsResponse);
+        
+        // Mock the describeDBClusterParameterGroups to throw NeptuneException
+        when(mockNeptuneClient.describeDBClusterParameterGroups(any(DescribeDbClusterParameterGroupsRequest.class)))
+                .thenThrow(NeptuneException.builder().message("Access Denied").build());
+        
+        // Mock the describeDBClusterParameters response
+        Parameter neptuneStreamsParameter = Parameter.builder()
+                .parameterName("neptune_streams")
+                .parameterValue("0")
+                .build();
+
+        DescribeDbClusterParametersResponse mockParametersResponse = DescribeDbClusterParametersResponse.builder()
+                .parameters(Collections.singletonList(neptuneStreamsParameter))
+                .build();
+
+        when(mockNeptuneClient.describeDBClusterParameters(any(DescribeDbClusterParametersRequest.class)))
+                .thenReturn(mockParametersResponse);
+        
+        // Mock the describeDBInstances response
+        Endpoint mockEndpoint = Endpoint.builder()
+                .address("instance-1.test.us-east-1.neptune.amazonaws.com")
+                .port(8182)
+                .build();
+
+        DBInstance mockDbInstance = DBInstance.builder()
+                .dbInstanceIdentifier("instance-1")
+                .dbInstanceClass("db.r5.large")
+                .dbParameterGroups(Collections.singletonList(
+                        DBParameterGroupStatus.builder()
+                                .dbParameterGroupName("default.neptune1")
+                                .build()
+                ))
+                .endpoint(mockEndpoint)
+                .build();
+
+        DescribeDbInstancesResponse mockDescribeDbInstancesResponse = DescribeDbInstancesResponse.builder()
+                .dbInstances(Collections.singletonList(mockDbInstance))
+                .build();
+
+        when(mockNeptuneClient.describeDBInstances(any(DescribeDbInstancesRequest.class)))
+                .thenReturn(mockDescribeDbInstancesResponse);
+        
+        // Create supplier for mock NeptuneClient
+        Supplier<NeptuneClient> mockNeptuneClientSupplier = () -> mockNeptuneClient;
+        
+        // Call the method under test
+        NeptuneClusterMetadata clusterMetadata = NeptuneClusterMetadata.createFromClusterId("test", mockNeptuneClientSupplier);
+        
+        // Verify the parameter group family is correctly determined
+        assertEquals(expectedParameterGroupFamily, clusterMetadata.dbParameterGroupFamily());
+    }
+}


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Neptune export primarily relies on a `DescribeDbClusterParameterGroups` request to determine the appropriate parameter group family for a cluster. There is however a fallback mechanism to infer it from the Neptune engine version. This fallback is primarily used in cases where the user does not have sufficient IAM permissions for the `DescribeDbClusterParameterGroups` request.

The existing version-based logic was sufficient for Neptune engine versions <= 1.3.x.x, although could not match parameter group families for neptune1.4 or newer. This logic is being updated to directly inject the major and minor versions into the parameter group family to better future proof for new Neptune versions.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

