### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/maven_build_and_verify.yml
+++ b/.github/workflows/maven_build_and_verify.yml
@@ -26,6 +26,9 @@ on:
 env:
   SIGNING_ENABLED: ${{ github.event.inputs.signJarArtifacts }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/remove_old_artifacts.yml
+++ b/.github/workflows/remove_old_artifacts.yml
@@ -5,6 +5,9 @@ on:
     # Every day at 1am
     - cron: '0 1 * * *'
 
+permissions:
+  actions: write
+
 jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -12,6 +12,9 @@ on:
   pull_request:
     branches: [ "develop" ]
 
+permissions:
+  contents: read
+
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.