### PR TITLE
Fix --clone-cluster-enable-audit-logs overriding other Neptune cluster parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Amazon Neptune Export CHANGELOG
 
-## Neptune Export v2.0.2 (Release Date: TBD):
+## Neptune Export v2.0.3 (Release Date: TBD):
 
 ### New Features and Improvements:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,20 @@
 # Amazon Neptune Export CHANGELOG
 
+## Neptune Export v2.0.2 (Release Date: TBD):
+
+### New Features and Improvements:
+
+
+
+### Bug Fixes:
+
+- Fix --clone-cluster-enable-audit-logs overriding other Neptune cluster parameters
+
 ## Neptune Export v2.0.2 (Release Date: June 16, 2025):
 
 ### Bug Fixes:
 
-* Fix fallback for finding parameter group families via Neptune engine version
+- Fix fallback for finding parameter group families via Neptune engine version
 
 ## Neptune Export v2.0.1 (Release Date: June 10, 2025):
 

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -322,83 +322,15 @@ public class AddCloneTask {
         String neptuneStreamsParameterValue = sourceClusterMetadata.isStreamEnabled() ? "1" : "0";
 
         try {
-            Collection<Parameter> parameters = new ArrayList<>(4);
-            parameters.add(Parameter.builder()
-                    .parameterName("neptune_enforce_ssl")
-                    .parameterValue("1")
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build());
-            parameters.add(Parameter.builder()
-                    .parameterName("neptune_query_timeout")
-                    .parameterValue("2147483647")
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build());
-            parameters.add(Parameter.builder()
-                    .parameterName("neptune_streams")
-                    .parameterValue(neptuneStreamsParameterValue)
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build());
-
-            if (this.enableAuditLogs) {
-                logger.debug("Adding neptune_enable_audit_log parameter");
-                parameters.add(Parameter.builder()
-                        .parameterName("neptune_enable_audit_log")
-                        .parameterValue("1")
-                        .applyMethod(ApplyMethod.PENDING_REBOOT)
-                        .build());
-            }
-
-            ModifyDbClusterParameterGroupRequest.Builder requestBuilder = ModifyDbClusterParameterGroupRequest.builder()
+            neptune.modifyDBClusterParameterGroup(ModifyDbClusterParameterGroupRequest.builder()
                     .dbClusterParameterGroupName(dbClusterParameterGroup.dbClusterParameterGroupName())
-                    .parameters(parameters);
-
-            neptune.modifyDBClusterParameterGroup(requestBuilder.build());
+                    .parameters(buildClusterParameters(true, neptuneStreamsParameterValue))
+                    .build());
         } catch (NeptuneException e) {
-            Collection<Parameter> parameters = new ArrayList<>(3);
-            parameters.add(Parameter.builder()
-                    .parameterName("neptune_query_timeout")
-                    .parameterValue("2147483647")
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build());
-            parameters.add(Parameter.builder()
-                    .parameterName("neptune_streams")
-                    .parameterValue(neptuneStreamsParameterValue)
-                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                    .build());
-
-            if (this.enableAuditLogs) {
-                logger.debug("Adding neptune_enable_audit_log parameter");
-                parameters.add(Parameter.builder()
-                        .parameterName("neptune_enable_audit_log")
-                        .parameterValue("1")
-                        .applyMethod(ApplyMethod.PENDING_REBOOT)
-                        .build());
-            }
-
-
-            ModifyDbClusterParameterGroupRequest.Builder requestBuilder = ModifyDbClusterParameterGroupRequest.builder()
+            neptune.modifyDBClusterParameterGroup(ModifyDbClusterParameterGroupRequest.builder()
                     .dbClusterParameterGroupName(dbClusterParameterGroup.dbClusterParameterGroupName())
-                    .parameters(
-                            Parameter.builder()
-                                    .parameterName("neptune_query_timeout")
-                                    .parameterValue("2147483647")
-                                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                                    .build(),
-                            Parameter.builder()
-                                    .parameterName("neptune_streams")
-                                    .parameterValue(neptuneStreamsParameterValue)
-                                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                                    .build());
-
-            if (this.enableAuditLogs) {
-                requestBuilder = requestBuilder.parameters(Parameter.builder()
-                        .parameterName("neptune_enable_audit_log")
-                        .parameterValue("1")
-                        .applyMethod(ApplyMethod.PENDING_REBOOT)
-                        .build());
-            }
-
-            neptune.modifyDBClusterParameterGroup(requestBuilder.build());
+                    .parameters(buildClusterParameters(false, neptuneStreamsParameterValue))
+                    .build());
         }
 
         List<Parameter> dbClusterParameters = neptune.describeDBClusterParameters(
@@ -430,6 +362,36 @@ public class AddCloneTask {
         System.err.println(String.format("DB cluster parameter group : %s", dbClusterParameterGroup.dbClusterParameterGroupName()));
 
         return dbClusterParameterGroup;
+    }
+
+    private Collection<Parameter> buildClusterParameters(boolean includeEnforceSsl, String neptuneStreamsParameterValue) {
+        Collection<Parameter> parameters = new ArrayList<>(4);
+        if (includeEnforceSsl) {
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_enforce_ssl")
+                    .parameterValue("1")
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+        }
+        parameters.add(Parameter.builder()
+                .parameterName("neptune_query_timeout")
+                .parameterValue("2147483647")
+                .applyMethod(ApplyMethod.PENDING_REBOOT)
+                .build());
+        parameters.add(Parameter.builder()
+                .parameterName("neptune_streams")
+                .parameterValue(neptuneStreamsParameterValue)
+                .applyMethod(ApplyMethod.PENDING_REBOOT)
+                .build());
+        if (this.enableAuditLogs) {
+            logger.debug("Adding neptune_enable_audit_log parameter");
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_enable_audit_log")
+                    .parameterValue("1")
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+        }
+        return parameters;
     }
 
     private void createInstance(String name,

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -345,7 +345,7 @@ public class AddCloneTask {
                         parameter.parameterValue().equals("2147483647"))) {
             count++;
             if (count >= 30) {
-                throw new IllegalStateException("Failed to create DB cluster parameter group: " + dbClusterParameterGroup.dbClusterParameterGroupName() + "after 5 minutes");
+                throw new IllegalStateException("Failed to create DB cluster parameter group: " + dbClusterParameterGroup.dbClusterParameterGroupName() + " after 5 minutes");
             }
             try {
                 Thread.sleep(10000);

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -407,9 +407,14 @@ public class AddCloneTask {
                                 .build()
                 ).parameters();
 
+        int count = 0;
         while (dbClusterParameters.stream().noneMatch(parameter ->
                 parameter.parameterName().equals("neptune_query_timeout") &&
                         parameter.parameterValue().equals("2147483647"))) {
+            count++;
+            if (count >= 30) {
+                throw new IllegalStateException("Failed to create DB cluster parameter group: " + dbClusterParameterGroup.dbClusterParameterGroupName() + "after 5 minutes");
+            }
             try {
                 Thread.sleep(10000);
             } catch (InterruptedException e) {

--- a/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
+++ b/src/main/java/com/amazonaws/services/neptune/cluster/AddCloneTask.java
@@ -322,36 +322,60 @@ public class AddCloneTask {
         String neptuneStreamsParameterValue = sourceClusterMetadata.isStreamEnabled() ? "1" : "0";
 
         try {
-            ModifyDbClusterParameterGroupRequest.Builder requestBuilder = ModifyDbClusterParameterGroupRequest.builder()
-                    .dbClusterParameterGroupName(dbClusterParameterGroup.dbClusterParameterGroupName())
-                    .parameters(
-                            Parameter.builder()
-                                    .parameterName("neptune_enforce_ssl")
-                                    .parameterValue("1")
-                                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                                    .build(),
-                            Parameter.builder()
-                                    .parameterName("neptune_query_timeout")
-                                    .parameterValue("2147483647")
-                                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                                    .build(),
-                            Parameter.builder()
-                                    .parameterName("neptune_streams")
-                                    .parameterValue(neptuneStreamsParameterValue)
-                                    .applyMethod(ApplyMethod.PENDING_REBOOT)
-                                    .build());
+            Collection<Parameter> parameters = new ArrayList<>(4);
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_enforce_ssl")
+                    .parameterValue("1")
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_query_timeout")
+                    .parameterValue("2147483647")
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_streams")
+                    .parameterValue(neptuneStreamsParameterValue)
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
 
             if (this.enableAuditLogs) {
                 logger.debug("Adding neptune_enable_audit_log parameter");
-                requestBuilder = requestBuilder.parameters(Parameter.builder()
+                parameters.add(Parameter.builder()
                         .parameterName("neptune_enable_audit_log")
                         .parameterValue("1")
                         .applyMethod(ApplyMethod.PENDING_REBOOT)
                         .build());
             }
 
+            ModifyDbClusterParameterGroupRequest.Builder requestBuilder = ModifyDbClusterParameterGroupRequest.builder()
+                    .dbClusterParameterGroupName(dbClusterParameterGroup.dbClusterParameterGroupName())
+                    .parameters(parameters);
+
             neptune.modifyDBClusterParameterGroup(requestBuilder.build());
         } catch (NeptuneException e) {
+            Collection<Parameter> parameters = new ArrayList<>(3);
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_query_timeout")
+                    .parameterValue("2147483647")
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+            parameters.add(Parameter.builder()
+                    .parameterName("neptune_streams")
+                    .parameterValue(neptuneStreamsParameterValue)
+                    .applyMethod(ApplyMethod.PENDING_REBOOT)
+                    .build());
+
+            if (this.enableAuditLogs) {
+                logger.debug("Adding neptune_enable_audit_log parameter");
+                parameters.add(Parameter.builder()
+                        .parameterName("neptune_enable_audit_log")
+                        .parameterValue("1")
+                        .applyMethod(ApplyMethod.PENDING_REBOOT)
+                        .build());
+            }
+
+
             ModifyDbClusterParameterGroupRequest.Builder requestBuilder = ModifyDbClusterParameterGroupRequest.builder()
                     .dbClusterParameterGroupName(dbClusterParameterGroup.dbClusterParameterGroupName())
                     .parameters(

--- a/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
@@ -38,7 +38,9 @@ import software.amazon.awssdk.services.neptune.model.RestoreDbClusterToPointInTi
 import software.amazon.awssdk.services.neptune.model.RestoreDbClusterToPointInTimeResponse;
 
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -72,6 +74,21 @@ public class AddCloneTaskTest {
         // Assert that "neptune_enable_audit_log" parameter has not been set
         assertEquals(0, capturedParamsRequest.parameters().stream().filter((p) -> (p.parameterName().equals("neptune_enable_audit_log"))).count());
 
+        // Assert that standard parameters have been set
+        List<Parameter> queryTimeoutParams = capturedParamsRequest.parameters().stream()
+                .filter((p) -> (p.parameterName().equals("neptune_query_timeout")))
+                .peek((parameter -> assertEquals("2147483647", parameter.parameterValue())))
+                .collect(Collectors.toList());
+        assertEquals(1, queryTimeoutParams.size());
+
+        List<Parameter> enforceSslParams = capturedParamsRequest.parameters().stream()
+                .filter((p) -> (p.parameterName().equals("neptune_enforce_ssl")))
+                .peek((parameter -> assertEquals("1", parameter.parameterValue())))
+                .collect(Collectors.toList());
+        assertEquals(1, queryTimeoutParams.size());
+
+        assertEquals(1, capturedParamsRequest.parameters().stream().filter((p) -> (p.parameterName().equals("neptune_streams"))).count());
+
         RestoreDbClusterToPointInTimeRequest capturedCloneRequest = cloneClusterRequestCaptor.getValue();
 
         // Assert that cluster log exports are disabled
@@ -99,11 +116,26 @@ public class AddCloneTaskTest {
         ModifyDbClusterParameterGroupRequest capturedParamsRequest = clusterParamsCaptor.getValue();
 
         // Assert that "neptune_enable_audit_log" parameter exists and has been set to "1"
-        assertEquals(1,
-                capturedParamsRequest.parameters().stream()
-                        .filter((p) -> (p.parameterName().equals("neptune_enable_audit_log")))
-                        .peek((parameter -> assertEquals("1", parameter.parameterValue())))
-                        .count());
+        List<Parameter> auditLogParams = capturedParamsRequest.parameters().stream()
+                .filter((p) -> (p.parameterName().equals("neptune_enable_audit_log")))
+                .peek((parameter -> assertEquals("1", parameter.parameterValue())))
+                .collect(Collectors.toList());
+        assertEquals(1, auditLogParams.size());
+
+        // Assert that standard parameters have been set
+        List<Parameter> queryTimeoutParams = capturedParamsRequest.parameters().stream()
+                .filter((p) -> (p.parameterName().equals("neptune_query_timeout")))
+                .peek((parameter -> assertEquals("2147483647", parameter.parameterValue())))
+                .collect(Collectors.toList());
+        assertEquals(1, queryTimeoutParams.size());
+
+        List<Parameter> enforceSslParams = capturedParamsRequest.parameters().stream()
+                .filter((p) -> (p.parameterName().equals("neptune_enforce_ssl")))
+                .peek((parameter -> assertEquals("1", parameter.parameterValue())))
+                .collect(Collectors.toList());
+        assertEquals(1, queryTimeoutParams.size());
+
+        assertEquals(1, capturedParamsRequest.parameters().stream().filter((p) -> (p.parameterName().equals("neptune_streams"))).count());
 
         RestoreDbClusterToPointInTimeRequest capturedCloneRequest = cloneClusterRequestCaptor.getValue();
 

--- a/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/cluster/AddCloneTaskTest.java
@@ -46,6 +46,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -85,7 +86,7 @@ public class AddCloneTaskTest {
                 .filter((p) -> (p.parameterName().equals("neptune_enforce_ssl")))
                 .peek((parameter -> assertEquals("1", parameter.parameterValue())))
                 .collect(Collectors.toList());
-        assertEquals(1, queryTimeoutParams.size());
+        assertEquals(1, enforceSslParams.size());
 
         assertEquals(1, capturedParamsRequest.parameters().stream().filter((p) -> (p.parameterName().equals("neptune_streams"))).count());
 
@@ -133,7 +134,7 @@ public class AddCloneTaskTest {
                 .filter((p) -> (p.parameterName().equals("neptune_enforce_ssl")))
                 .peek((parameter -> assertEquals("1", parameter.parameterValue())))
                 .collect(Collectors.toList());
-        assertEquals(1, queryTimeoutParams.size());
+        assertEquals(1, enforceSslParams.size());
 
         assertEquals(1, capturedParamsRequest.parameters().stream().filter((p) -> (p.parameterName().equals("neptune_streams"))).count());
 
@@ -141,6 +142,61 @@ public class AddCloneTaskTest {
 
         // Assert that cluster audit log exports are enabled
         assertEquals(Arrays.asList("audit"), capturedCloneRequest.enableCloudwatchLogsExports());
+    }
+
+    @Test
+    public void shouldNotSetAuditLogsOrSslWhenEnableAuditLogsIsFalseAndFallbackIsUsed() {
+        NeptuneClient mockNeptune = createMockNeptune();
+        when(mockNeptune.modifyDBClusterParameterGroup((ModifyDbClusterParameterGroupRequest) any()))
+                .thenThrow(NeptuneException.builder().message("Test Exception").build())
+                .thenReturn(null);
+        ArgumentCaptor<ModifyDbClusterParameterGroupRequest> clusterParamsCaptor = ArgumentCaptor.forClass(ModifyDbClusterParameterGroupRequest.class);
+
+        AddCloneTask noLogsTask = new AddCloneTask("sourceClusterId", "targetClusterId", "db_r5_large", 1, null,
+                () -> mockNeptune, null, false);
+
+        try (MockedStatic<NeptuneClusterMetadata> classMock = mockStatic(NeptuneClusterMetadata.class)) {
+            classMock.when(() -> NeptuneClusterMetadata.createFromClusterId(any(), any())).thenReturn(mock(NeptuneClusterMetadata.class));
+            noLogsTask.execute();
+        }
+
+        verify(mockNeptune, times(2)).modifyDBClusterParameterGroup(clusterParamsCaptor.capture());
+        ModifyDbClusterParameterGroupRequest fallbackRequest = clusterParamsCaptor.getAllValues().get(1);
+
+        assertEquals(0, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_enable_audit_log")).count());
+        assertEquals(0, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_enforce_ssl")).count());
+        assertEquals(1, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_query_timeout")).count());
+        assertEquals(1, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_streams")).count());
+    }
+
+    @Test
+    public void shouldSetAuditLogsButNotSslWhenEnableAuditLogsIsTrueAndFallbackIsUsed() {
+        NeptuneClient mockNeptune = createMockNeptune();
+        when(mockNeptune.modifyDBClusterParameterGroup((ModifyDbClusterParameterGroupRequest) any()))
+                .thenThrow(NeptuneException.builder().message("Test Exception").build())
+                .thenReturn(null);
+        ArgumentCaptor<ModifyDbClusterParameterGroupRequest> clusterParamsCaptor = ArgumentCaptor.forClass(ModifyDbClusterParameterGroupRequest.class);
+
+        AddCloneTask auditLogsTask = new AddCloneTask("sourceClusterId", "targetClusterId", "db_r5_large", 1, null,
+                () -> mockNeptune, null, true);
+
+        try (MockedStatic<NeptuneClusterMetadata> classMock = mockStatic(NeptuneClusterMetadata.class)) {
+            classMock.when(() -> NeptuneClusterMetadata.createFromClusterId(any(), any())).thenReturn(mock(NeptuneClusterMetadata.class));
+            auditLogsTask.execute();
+        }
+
+        verify(mockNeptune, times(2)).modifyDBClusterParameterGroup(clusterParamsCaptor.capture());
+        ModifyDbClusterParameterGroupRequest fallbackRequest = clusterParamsCaptor.getAllValues().get(1);
+
+        List<Parameter> auditLogParams = fallbackRequest.parameters().stream()
+                .filter(p -> p.parameterName().equals("neptune_enable_audit_log"))
+                .peek(p -> assertEquals("1", p.parameterValue()))
+                .collect(Collectors.toList());
+        assertEquals(1, auditLogParams.size());
+
+        assertEquals(0, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_enforce_ssl")).count());
+        assertEquals(1, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_query_timeout")).count());
+        assertEquals(1, fallbackRequest.parameters().stream().filter(p -> p.parameterName().equals("neptune_streams")).count());
     }
 
     @Test


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Fixes a bug in which the addition of "neptune_enable_audit_log" parameter in the cluster clone would override the other cluster parameters, including "neptune_query_timeout" and "neptune_streams". This resulted in exports getting stuck in an infinite loop as the presence of "neptune_query_timeout" is used for validating successful parameter group creation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

