### PR TITLE
Revert RDF exports to use SPARQL over GSP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Amazon Neptune Export CHANGELOG
 
+## Neptune Export v2.0.3 (Release Date: TBD):
+
+### New Features and Improvements:
+
+* Use SPARQL over GSP for complete and named-graph exports in `export-rdf` for Neptune versions >= 1.3.2.0
+
+### Bug Fixes:
+
+* Fix missing graph fields for complete and named-graph exports in `export-rdf` with `nquads` format
+
 ## Neptune Export v2.0.2 (Release Date: June 16, 2025):
 
 ### Bug Fixes:

--- a/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
+++ b/src/main/java/com/amazonaws/services/neptune/ExportRdfGraph.java
@@ -71,7 +71,7 @@ public class ExportRdfGraph extends NeptuneExportCommand implements Runnable {
                     GetLastEventIdStrategy getLastEventIdStrategy = streams.lastEventIdStrategy(cluster, eventIdFileResource);
                     getLastEventIdStrategy.saveLastEventId("sparql");
 
-                    try (NeptuneSparqlClient client = NeptuneSparqlClient.create(cluster.connectionConfig(), featureToggles())) {
+                    try (NeptuneSparqlClient client = NeptuneSparqlClient.create(cluster.connectionConfig(), cluster.clusterMetadata(), featureToggles())) {
 
                         ExportRdfJob job = exportScope.createJob(client, target.config(directories));
                         job.execute();

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -65,7 +65,22 @@ public class NeptuneSparqlClient implements AutoCloseable {
             .set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
 
     // Beyond this version, there are no longer performance or stability benefits from using GSP instead of SPARQL for exports
-    private static final String NO_GSP_VERSION = "1.3.2.0";
+    static final int[] NO_GSP_VERSION = {1, 3, 2, 0};
+
+    static boolean isVersionAtLeast(String version, int[] threshold) {
+        try {
+            String[] parts = version.split("\\.");
+            if (parts.length != 4) return true; // Default true if version does not match expected format
+            for (int i = 0; i < 4; i++) {
+                int v = Integer.parseInt(parts[i]);
+                if (v > threshold[i]) return true;
+                if (v < threshold[i]) return false;
+            }
+            return true;
+        } catch (NumberFormatException e) {
+            return true; // Default true if version cannot be parsed
+        }
+    }
 
     public static NeptuneSparqlClient create(ConnectionConfig config, NeptuneClusterMetadata clusterMetadata, FeatureToggles featureToggles) {
 
@@ -180,10 +195,14 @@ public class NeptuneSparqlClient implements AutoCloseable {
         }
     }
 
-    public void executeCompleteExport(RdfTargetConfig targetConfig) throws IOException {
-        if(clusterMetadata.engineVersion().compareTo(NO_GSP_VERSION) >= 0
+    boolean shouldUseSPARQL(RdfTargetConfig targetConfig) {
+        return isVersionAtLeast(clusterMetadata.engineVersion(), NO_GSP_VERSION)
                 || targetConfig.format() == RdfExportFormat.nquads
-                || featureToggles.containsFeature(FeatureToggle.No_GSP)) {
+                || featureToggles.containsFeature(FeatureToggle.No_GSP);
+    }
+
+    public void executeCompleteExport(RdfTargetConfig targetConfig) throws IOException {
+        if(shouldUseSPARQL(targetConfig)) {
             executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }", targetConfig);
         } else {
             executeGSPExport(targetConfig, "default");
@@ -191,9 +210,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
     }
 
     public void executeNamedGraphExport(RdfTargetConfig targetConfig, String namedGraph) throws IOException {
-        if(clusterMetadata.engineVersion().compareTo(NO_GSP_VERSION) >= 0
-                || targetConfig.format() == RdfExportFormat.nquads
-                || featureToggles.containsFeature(FeatureToggle.No_GSP)) {
+        if(shouldUseSPARQL(targetConfig)) {
             executeTupleQuery(String.format("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <%s>) .}", namedGraph), targetConfig);
         } else {
             executeGSPExport(targetConfig, "graph="+namedGraph);

--- a/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
+++ b/src/main/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClient.java
@@ -15,10 +15,12 @@ package com.amazonaws.services.neptune.rdf;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.neptune.auth.NeptuneSigV4SignerException;
 import com.amazonaws.services.neptune.cluster.ConnectionConfig;
+import com.amazonaws.services.neptune.cluster.NeptuneClusterMetadata;
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.io.OutputWriter;
 import com.amazonaws.services.neptune.rdf.io.NeptuneExportSparqlRepository;
+import com.amazonaws.services.neptune.rdf.io.RdfExportFormat;
 import com.amazonaws.services.neptune.rdf.io.RdfTargetConfig;
 import com.amazonaws.services.neptune.util.EnvironmentVariableUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -62,7 +64,10 @@ public class NeptuneSparqlClient implements AutoCloseable {
             .addNonFatalError(BasicParserSettings.VERIFY_URI_SYNTAX)
             .set(BasicParserSettings.VERIFY_URI_SYNTAX, false);
 
-    public static NeptuneSparqlClient create(ConnectionConfig config, FeatureToggles featureToggles) {
+    // Beyond this version, there are no longer performance or stability benefits from using GSP instead of SPARQL for exports
+    private static final String NO_GSP_VERSION = "1.3.2.0";
+
+    public static NeptuneSparqlClient create(ConnectionConfig config, NeptuneClusterMetadata clusterMetadata, FeatureToggles featureToggles) {
 
         String serviceRegion = config.useIamAuth() ? EnvironmentVariableUtils.getMandatoryEnv("SERVICE_REGION") : null;
         AwsCredentialsProvider credentialsProvider = config.useIamAuth() ? config.getCredentialsProvider() : null;
@@ -83,7 +88,7 @@ public class NeptuneSparqlClient implements AutoCloseable {
                         )
                         .peek(AbstractRepository::init)
                         .collect(Collectors.toList()),
-                featureToggles, config);
+                featureToggles, config, clusterMetadata);
     }
 
     private static SPARQLRepository updateParser(SPARQLRepository repository) {
@@ -125,11 +130,13 @@ public class NeptuneSparqlClient implements AutoCloseable {
     private final Random random = new Random(DateTime.now().getMillis());
     private final FeatureToggles featureToggles;
     private final ConnectionConfig connectionConfig;
+    private final NeptuneClusterMetadata clusterMetadata;
 
-    private NeptuneSparqlClient(List<SPARQLRepository> repositories, FeatureToggles featureToggles, ConnectionConfig connectionConfig) {
+    private NeptuneSparqlClient(List<SPARQLRepository> repositories, FeatureToggles featureToggles, ConnectionConfig connectionConfig, NeptuneClusterMetadata clusterMetadata) {
         this.repositories = repositories;
         this.featureToggles = featureToggles;
         this.connectionConfig = connectionConfig;
+        this.clusterMetadata = clusterMetadata;
     }
 
     public void executeTupleQuery(String sparql, RdfTargetConfig targetConfig) throws IOException {
@@ -174,7 +181,9 @@ public class NeptuneSparqlClient implements AutoCloseable {
     }
 
     public void executeCompleteExport(RdfTargetConfig targetConfig) throws IOException {
-        if(featureToggles.containsFeature(FeatureToggle.No_GSP)) {
+        if(clusterMetadata.engineVersion().compareTo(NO_GSP_VERSION) >= 0
+                || targetConfig.format() == RdfExportFormat.nquads
+                || featureToggles.containsFeature(FeatureToggle.No_GSP)) {
             executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }", targetConfig);
         } else {
             executeGSPExport(targetConfig, "default");
@@ -182,7 +191,9 @@ public class NeptuneSparqlClient implements AutoCloseable {
     }
 
     public void executeNamedGraphExport(RdfTargetConfig targetConfig, String namedGraph) throws IOException {
-        if(featureToggles.containsFeature(FeatureToggle.No_GSP)) {
+        if(clusterMetadata.engineVersion().compareTo(NO_GSP_VERSION) >= 0
+                || targetConfig.format() == RdfExportFormat.nquads
+                || featureToggles.containsFeature(FeatureToggle.No_GSP)) {
             executeTupleQuery(String.format("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <%s>) .}", namedGraph), targetConfig);
         } else {
             executeGSPExport(targetConfig, "graph="+namedGraph);

--- a/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
@@ -29,6 +29,9 @@ import org.eclipse.rdf4j.repository.sparql.SPARQLRepository;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
 
 import java.io.ByteArrayInputStream;
 import java.io.File;
@@ -36,6 +39,7 @@ import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
@@ -48,177 +52,225 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
+@RunWith(Enclosed.class)
 public class NeptuneSparqlClientTest {
 
-    private SPARQLRepository mockSPARQLRepository;
-    private SailRepository sailRepository;
-    private final String testDataNTriples = "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://aws.amazon.com/neptune/csv2rdf/class/Version> .\n" +
-            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> \"version\" .\n" +
-            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> \"0.77\" .\n" +
-            "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> \"Version: 0.77 Generated: 2017-10-06 16:24:52 UTC\\nGraph created by Kelvin R. Lawrence\\nPlease let me know of any errors you find in the graph.\" .\n";
+    public static class StandardTests {
 
-    private OutputWriter writer;
+        private SPARQLRepository mockSPARQLRepository;
+        private SailRepository sailRepository;
+        private final String testDataNTriples = "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://www.w3.org/1999/02/22-rdf-syntax-ns#type> <http://aws.amazon.com/neptune/csv2rdf/class/Version> .\n" +
+                "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/type> \"version\" .\n" +
+                "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/code> \"0.77\" .\n" +
+                "<http://aws.amazon.com/neptune/csv2rdf/resource/0> <http://aws.amazon.com/neptune/csv2rdf/datatypeProperty/desc> \"Version: 0.77 Generated: 2017-10-06 16:24:52 UTC\\nGraph created by Kelvin R. Lawrence\\nPlease let me know of any errors you find in the graph.\" .\n";
 
-    @Before
-    public void setup() throws IOException {
-        // init a mock SPARQLRepository which is backed by a SailRepository containing test data.
-        sailRepository = new SailRepository(new MemoryStore());
-        sailRepository.getConnection().add(new File("src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl"));
-        mockSPARQLRepository = mock(SPARQLRepository.class);
+        private OutputWriter writer;
 
-        HttpClient mockHttpClient = mock(HttpClient.class);
-        BasicHttpResponse response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "Success");
-        BasicHttpEntity httpEntity = new BasicHttpEntity();
-        httpEntity.setContent(new ByteArrayInputStream(new byte[]{}));
-        response.setEntity(httpEntity);
-        doReturn(response).when(mockHttpClient).execute(any());
+        @Before
+        public void setup() throws IOException {
+            sailRepository = new SailRepository(new MemoryStore());
+            sailRepository.getConnection().add(new File("src/test/resources/IntegrationTest/testExportRdfVersionNamedGraph/statements/statements.ttl"));
+            mockSPARQLRepository = mock(SPARQLRepository.class);
 
-        doReturn(sailRepository.getConnection()).when(mockSPARQLRepository).getConnection();
-        doReturn(sailRepository.getHttpClientSessionManager()).when(mockSPARQLRepository).getHttpClientSessionManager();
-        doReturn(sailRepository.getValueFactory()).when(mockSPARQLRepository).getValueFactory();
-        doReturn(mockHttpClient).when(mockSPARQLRepository).getHttpClient();
+            HttpClient mockHttpClient = mock(HttpClient.class);
+            BasicHttpResponse response = new BasicHttpResponse(new ProtocolVersion("HTTP", 1, 1), 200, "Success");
+            BasicHttpEntity httpEntity = new BasicHttpEntity();
+            httpEntity.setContent(new ByteArrayInputStream(new byte[]{}));
+            response.setEntity(httpEntity);
+            doReturn(response).when(mockHttpClient).execute(any());
+
+            doReturn(sailRepository.getConnection()).when(mockSPARQLRepository).getConnection();
+            doReturn(sailRepository.getHttpClientSessionManager()).when(mockSPARQLRepository).getHttpClientSessionManager();
+            doReturn(sailRepository.getValueFactory()).when(mockSPARQLRepository).getValueFactory();
+            doReturn(mockHttpClient).when(mockSPARQLRepository).getHttpClient();
+        }
+
+        @Test
+        public void testExecuteTupleQuerySelectAll() throws Exception {
+            StringWriter outputWriter = new StringWriter();
+            NeptuneSparqlClient client = createNeptuneSparqlClient();
+
+            client.executeTupleQuery("SELECT * WHERE { BIND(<http://aws.amazon.com/neptune/csv2rdf/graph/version> AS ?g) ?s ?p ?o }", getMockTargetConfig(outputWriter));
+
+            assertEquals(testDataNTriples, outputWriter.toString());
+        }
+
+        @Test
+        public void completeExportShouldExportDefaultGraphViaGSPWithOldNeptune() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeCompleteExport(targetConfig);
+
+            verify(client, times(1)).executeGSPExport(targetConfig, "default");
+            verify(client, never()).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void completeExportShouldExportSPARQLWithNewNeptune() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeCompleteExport(targetConfig);
+
+            verify(client, never()).executeGSPExport(any(), any());
+            verify(client, times(1)).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void completeExportShouldExportSPARQLWithOldNeptuneAndNQuads() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
+
+            client.executeCompleteExport(targetConfig);
+
+            verify(client, never()).executeGSPExport(any(), any());
+            verify(client, times(1)).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void completeExportShouldExecuteTupleQueryIfNoGSP() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeCompleteExport(targetConfig);
+
+            verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }", targetConfig);
+            verify(client, never()).executeGSPExport(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void namedGraphExportShouldExportViaGSPWithOldNeptune() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeNamedGraphExport(targetConfig, "GraphName");
+
+            verify(client, times(1)).executeGSPExport(targetConfig, "graph=GraphName");
+            verify(client, never()).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void namedGraphExportShouldExportViaSPARQLWithNewNeptune() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
+
+            verify(client, never()).executeGSPExport(any(), any());
+            verify(client, times(1)).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void namedGraphExportShouldExportViaSPARQLWithOldNeptuneAndNQuads() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
+
+            client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
+
+            verify(client, never()).executeGSPExport(any(), any());
+            verify(client, times(1)).executeTupleQuery(any(), any());
+            verifyWriterClosed();
+        }
+
+        @Test
+        public void namedGraphExportShouldExecuteTupleQueryIfNoGSP() throws Exception {
+            NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
+            RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+            client.executeNamedGraphExport(targetConfig, "http://example.com");
+
+            verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <http://example.com>) .}", targetConfig);
+            verify(client, never()).executeGSPExport(any(), any());
+            verifyWriterClosed();
+        }
+
+        private NeptuneSparqlClient createNeptuneSparqlClient(FeatureToggle... featureToggles) throws IOException {
+            return createNeptuneSparqlClient("1.4.6.3", featureToggles);
+        }
+
+        private NeptuneSparqlClient createNeptuneSparqlClient(String engineVersion, FeatureToggle... featureToggles) throws IOException {
+            ConnectionConfig mockConnectionConfig = mock(ConnectionConfig.class);
+            doReturn(Collections.singletonList("localhost")).when(mockConnectionConfig).endpoints();
+
+            NeptuneClusterMetadata mockClusterMetadata = mock(NeptuneClusterMetadata.class);
+            doReturn(engineVersion).when(mockClusterMetadata).engineVersion();
+
+            NeptuneSparqlClient client = spy(NeptuneSparqlClient.create(mockConnectionConfig, mockClusterMetadata, new FeatureToggles(Arrays.asList(featureToggles))));
+            doReturn(mockSPARQLRepository).when(client).chooseRepository();
+            return client;
+        }
+
+        private RdfTargetConfig getMockTargetConfig(Writer outputWriter) throws Exception {
+            return getMockTargetConfig(outputWriter, RdfExportFormat.ntriples);
+        }
+
+        private RdfTargetConfig getMockTargetConfig(Writer outputWriter, RdfExportFormat format) throws Exception {
+            RdfTargetConfig target = spy(new RdfTargetConfig(null, null, null, format));
+            writer = spy(new PrintOutputWriter("TestOutputWriter", outputWriter));
+            doReturn(writer).when(target).createOutputWriter();
+            verify(writer, never()).close();
+            return target;
+        }
+
+        private void verifyWriterClosed() throws Exception {
+            verify(writer, atLeastOnce()).close();
+        }
     }
 
-    @Test
-    public void testExecuteTupleQuerySelectAll() throws Exception {
-        StringWriter outputWriter = new StringWriter();
-        NeptuneSparqlClient client = createNeptuneSparqlClient();
+    @RunWith(Parameterized.class)
+    public static class ShouldUseSPARQLTests {
 
-        // Test data does not have named graphs but a ?g binding is required by TupleQueryHandler
-        client.executeTupleQuery("SELECT * WHERE { BIND(<http://aws.amazon.com/neptune/csv2rdf/graph/version> AS ?g) ?s ?p ?o }", getMockTargetConfig(outputWriter));
+        @Parameterized.Parameters(name = "version={0}, format={1}, No_GSP={2} => {3}")
+        public static Collection<Object[]> data() {
+            return Arrays.asList(new Object[][]{
+                    //version,   format,                   NoGSP, expect SPARQL
+                    {"1.2.0.0",  RdfExportFormat.ntriples, false, false},  // old version, no overrides
+                    {"1.3.2.0",  RdfExportFormat.ntriples, false, true},   // exactly at threshold
+                    {"1.4.6.3",  RdfExportFormat.ntriples, false, true},   // above threshold
+                    {"1.10.0.0", RdfExportFormat.ntriples, false, true},   // multi-digit + above threshold
+                    {"1.2.0.0",  RdfExportFormat.nquads,   false, true},   // nquads forces skip regardless of version
+                    {"1.4.6.3",  RdfExportFormat.nquads,   false, true},   // nquads + new version
+                    {"1.2.0.0",  RdfExportFormat.ntriples, true,  true},   // No_GSP toggle forces skip regardless of version
+                    {"1.4.6.3",  RdfExportFormat.ntriples, true,  true},   // No_GSP toggle + new version
+                    {"1.2.0.0",  RdfExportFormat.nquads,   true,  true},   // all three conditions active
+                    {"invalid",  RdfExportFormat.ntriples, false, true},   // malformed → use SPARQL
+                    {"",         RdfExportFormat.ntriples, false, true},   // empty → malformed
+                    {"1.3",      RdfExportFormat.ntriples, false, true},   // too few components
+                    {"1.3.2.0a", RdfExportFormat.ntriples, false, true},   // non-parsable → use SPARQL
 
-        assertEquals(testDataNTriples, outputWriter.toString());
-    }
+            });
+        }
 
-    @Test
-    public void completeExportShouldExportDefaultGraphViaGSPWithOldNeptune() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+        @Parameterized.Parameter(0) public String engineVersion;
+        @Parameterized.Parameter(1) public RdfExportFormat format;
+        @Parameterized.Parameter(2) public boolean hasNoGSPToggle;
+        @Parameterized.Parameter(3) public boolean expected;
 
-        client.executeCompleteExport(targetConfig);
+        @Test
+        public void shouldSkipGSPReturnsExpectedResult() throws Exception {
+            ConnectionConfig mockConnectionConfig = mock(ConnectionConfig.class);
+            doReturn(Collections.singletonList("localhost")).when(mockConnectionConfig).endpoints();
 
-        verify(client, times(1)).executeGSPExport(targetConfig, "default");
-        verify(client, never()).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
+            NeptuneClusterMetadata mockClusterMetadata = mock(NeptuneClusterMetadata.class);
+            doReturn(engineVersion).when(mockClusterMetadata).engineVersion();
 
-    @Test
-    public void completeExportShouldExportSPARQLWithNewNeptune() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+            FeatureToggles featureToggles = hasNoGSPToggle
+                    ? new FeatureToggles(Collections.singletonList(FeatureToggle.No_GSP))
+                    : new FeatureToggles(Collections.emptyList());
 
-        client.executeCompleteExport(targetConfig);
+            NeptuneSparqlClient client = NeptuneSparqlClient.create(mockConnectionConfig, mockClusterMetadata, featureToggles);
 
-        verify(client, never()).executeGSPExport(any(), any());
-        verify(client, times(1)).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
+            RdfTargetConfig mockTargetConfig = mock(RdfTargetConfig.class);
+            doReturn(format).when(mockTargetConfig).format();
 
-    @Test
-    public void completeExportShouldExportSPARQLWithOldNeptuneAndNQuads() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
-
-        client.executeCompleteExport(targetConfig);
-
-        verify(client, never()).executeGSPExport(any(), any());
-        verify(client, times(1)).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
-
-    @Test
-    public void completeExportShouldExecuteTupleQueryIfNoGSP() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
-
-        client.executeCompleteExport(targetConfig);
-
-        verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } }", targetConfig);
-        verify(client, never()).executeGSPExport(any(), any());
-        verifyWriterClosed();
-    }
-
-    @Test
-    public void namedGraphExportShouldExportViaGSPWithOldNeptune() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
-
-        client.executeNamedGraphExport(targetConfig, "GraphName");
-
-        verify(client, times(1)).executeGSPExport(targetConfig, "graph=GraphName");
-        verify(client, never()).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
-
-    @Test
-    public void namedGraphExportShouldExportViaSPARQLWithNewNeptune() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
-
-        client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
-
-        verify(client, never()).executeGSPExport(any(), any());
-        verify(client, times(1)).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
-
-    @Test
-    public void namedGraphExportShouldExportViaSPARQLWithOldNeptuneAndNQuads() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
-
-        client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
-
-        verify(client, never()).executeGSPExport(any(), any());
-        verify(client, times(1)).executeTupleQuery(any(), any());
-        verifyWriterClosed();
-    }
-
-    @Test
-    public void namedGraphExportShouldExecuteTupleQueryIfNoGSP() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient(FeatureToggle.No_GSP);
-        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
-
-        client.executeNamedGraphExport(targetConfig, "http://example.com");
-
-        verify(client, times(1)).executeTupleQuery("SELECT * WHERE { GRAPH ?g { ?s ?p ?o } FILTER(?g = <http://example.com>) .}", targetConfig);
-        verify(client, never()).executeGSPExport(any(), any());
-        verifyWriterClosed();
-    }
-
-    private NeptuneSparqlClient createNeptuneSparqlClient(FeatureToggle ... featureToggles) throws IOException {
-        return createNeptuneSparqlClient("1.4.6.3", featureToggles);
-    }
-
-    private NeptuneSparqlClient createNeptuneSparqlClient(String engineVersion, FeatureToggle ... featureToggles) throws IOException {
-        ConnectionConfig mockConnectionConfig = mock(ConnectionConfig.class);
-        doReturn(Collections.singletonList("localhost")).when(mockConnectionConfig).endpoints();
-
-        NeptuneClusterMetadata mockClusterMetadata = mock(NeptuneClusterMetadata.class);
-        doReturn(engineVersion).when(mockClusterMetadata).engineVersion();
-
-        NeptuneSparqlClient client = spy(NeptuneSparqlClient.create(mockConnectionConfig, mockClusterMetadata, new FeatureToggles(Arrays.asList(featureToggles))));
-
-        doReturn(mockSPARQLRepository).when(client).chooseRepository();
-
-        return client;
-    }
-
-    private RdfTargetConfig getMockTargetConfig(Writer outputWriter) throws Exception {
-        return getMockTargetConfig(outputWriter, RdfExportFormat.ntriples);
-    }
-
-    private RdfTargetConfig getMockTargetConfig(Writer outputWriter, RdfExportFormat format) throws Exception {
-        RdfTargetConfig target = spy(new RdfTargetConfig(null, null, null, format));
-        writer = spy(new PrintOutputWriter("TestOutputWriter", outputWriter));
-        doReturn(writer).when(target).createOutputWriter();
-
-        verify(writer, never()).close();
-
-        return target;
-    }
-
-    private void verifyWriterClosed() throws Exception {
-        verify(writer, atLeastOnce()).close();
+            assertEquals(expected, client.shouldUseSPARQL(mockTargetConfig));
+        }
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/rdf/NeptuneSparqlClientTest.java
@@ -13,6 +13,7 @@ permissions and limitations under the License.
 package com.amazonaws.services.neptune.rdf;
 
 import com.amazonaws.services.neptune.cluster.ConnectionConfig;
+import com.amazonaws.services.neptune.cluster.NeptuneClusterMetadata;
 import com.amazonaws.services.neptune.export.FeatureToggle;
 import com.amazonaws.services.neptune.export.FeatureToggles;
 import com.amazonaws.services.neptune.io.OutputWriter;
@@ -90,14 +91,38 @@ public class NeptuneSparqlClientTest {
     }
 
     @Test
-    public void completeExportShouldExportDefaultGraphViaGSP() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient();
+    public void completeExportShouldExportDefaultGraphViaGSPWithOldNeptune() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
         RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
 
         client.executeCompleteExport(targetConfig);
 
         verify(client, times(1)).executeGSPExport(targetConfig, "default");
         verify(client, never()).executeTupleQuery(any(), any());
+        verifyWriterClosed();
+    }
+
+    @Test
+    public void completeExportShouldExportSPARQLWithNewNeptune() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeCompleteExport(targetConfig);
+
+        verify(client, never()).executeGSPExport(any(), any());
+        verify(client, times(1)).executeTupleQuery(any(), any());
+        verifyWriterClosed();
+    }
+
+    @Test
+    public void completeExportShouldExportSPARQLWithOldNeptuneAndNQuads() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
+
+        client.executeCompleteExport(targetConfig);
+
+        verify(client, never()).executeGSPExport(any(), any());
+        verify(client, times(1)).executeTupleQuery(any(), any());
         verifyWriterClosed();
     }
 
@@ -114,14 +139,38 @@ public class NeptuneSparqlClientTest {
     }
 
     @Test
-    public void namedGraphExportShouldExportDefaultGraphViaGSP() throws Exception {
-        NeptuneSparqlClient client = createNeptuneSparqlClient();
+    public void namedGraphExportShouldExportViaGSPWithOldNeptune() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
         RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
 
         client.executeNamedGraphExport(targetConfig, "GraphName");
 
         verify(client, times(1)).executeGSPExport(targetConfig, "graph=GraphName");
         verify(client, never()).executeTupleQuery(any(), any());
+        verifyWriterClosed();
+    }
+
+    @Test
+    public void namedGraphExportShouldExportViaSPARQLWithNewNeptune() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.4.6.3");
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter());
+
+        client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
+
+        verify(client, never()).executeGSPExport(any(), any());
+        verify(client, times(1)).executeTupleQuery(any(), any());
+        verifyWriterClosed();
+    }
+
+    @Test
+    public void namedGraphExportShouldExportViaSPARQLWithOldNeptuneAndNQuads() throws Exception {
+        NeptuneSparqlClient client = createNeptuneSparqlClient("1.2.0.0");
+        RdfTargetConfig targetConfig = getMockTargetConfig(new StringWriter(), RdfExportFormat.nquads);
+
+        client.executeNamedGraphExport(targetConfig, "http://graphname.example.com");
+
+        verify(client, never()).executeGSPExport(any(), any());
+        verify(client, times(1)).executeTupleQuery(any(), any());
         verifyWriterClosed();
     }
 
@@ -138,10 +187,17 @@ public class NeptuneSparqlClientTest {
     }
 
     private NeptuneSparqlClient createNeptuneSparqlClient(FeatureToggle ... featureToggles) throws IOException {
+        return createNeptuneSparqlClient("1.4.6.3", featureToggles);
+    }
+
+    private NeptuneSparqlClient createNeptuneSparqlClient(String engineVersion, FeatureToggle ... featureToggles) throws IOException {
         ConnectionConfig mockConnectionConfig = mock(ConnectionConfig.class);
         doReturn(Collections.singletonList("localhost")).when(mockConnectionConfig).endpoints();
 
-        NeptuneSparqlClient client = spy(NeptuneSparqlClient.create(mockConnectionConfig, new FeatureToggles(Arrays.asList(featureToggles))));
+        NeptuneClusterMetadata mockClusterMetadata = mock(NeptuneClusterMetadata.class);
+        doReturn(engineVersion).when(mockClusterMetadata).engineVersion();
+
+        NeptuneSparqlClient client = spy(NeptuneSparqlClient.create(mockConnectionConfig, mockClusterMetadata, new FeatureToggles(Arrays.asList(featureToggles))));
 
         doReturn(mockSPARQLRepository).when(client).chooseRepository();
 
@@ -149,7 +205,11 @@ public class NeptuneSparqlClientTest {
     }
 
     private RdfTargetConfig getMockTargetConfig(Writer outputWriter) throws Exception {
-        RdfTargetConfig target = spy(new RdfTargetConfig(null, null, null, RdfExportFormat.ntriples));
+        return getMockTargetConfig(outputWriter, RdfExportFormat.ntriples);
+    }
+
+    private RdfTargetConfig getMockTargetConfig(Writer outputWriter, RdfExportFormat format) throws Exception {
+        RdfTargetConfig target = spy(new RdfTargetConfig(null, null, null, format));
         writer = spy(new PrintOutputWriter("TestOutputWriter", outputWriter));
         doReturn(writer).when(target).createOutputWriter();
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

GSP was previously used for full graph RDF exports as it resulted in improved stability for large exports.

As of Neptune 1.3.2.0, SPARQL exports now match the stability of GSP, and offer slightly better performance.

Additionally, SPARQL is now used regardless of the Neptune version when a format of nquads is used, as GSP does not produce the "G" field in results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

