### PR TITLE
Fixed usages of expectedBucketOwner which were unguarded against empty strings

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/ExportToS3NeptuneExportEventHandler.java
@@ -313,15 +313,17 @@ public class ExportToS3NeptuneExportEventHandler implements NeptuneExportEventHa
         logger.info("Uploading completion file to {}", completionFileS3ObjectInfo.key());
 
         try {
-            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
-                    .source(completionFile)
-                    .putObjectRequest(PutObjectRequest.builder()
+            PutObjectRequest.Builder putObjectRequestBuilder = PutObjectRequest.builder()
                             .bucket(completionFileS3ObjectInfo.bucket())
                             .key(completionFileS3ObjectInfo.key())
-                            .expectedBucketOwner(expectedBucketOwner)
                             .metadata(S3ObjectInfo.createObjectMetadata(completionFile.length(), sseKmsKeyId))
-                            .tagging(createObjectTags(profiles))
-                            .build())
+                            .tagging(createObjectTags(profiles));
+            if (StringUtils.isNotBlank(expectedBucketOwner)) {
+                putObjectRequestBuilder = putObjectRequestBuilder.expectedBucketOwner(expectedBucketOwner);
+            }
+            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
+                    .source(completionFile)
+                    .putObjectRequest(putObjectRequestBuilder.build())
                     .build();
 
             FileUpload upload = transferManager.uploadFile(uploadFileRequest);

--- a/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
@@ -257,14 +257,14 @@ public class NeptuneExportService {
     private void checkS3OutputIsEmpty() {
         S3Client s3 = S3Client.builder().build();
         S3ObjectInfo s3ObjectInfo = new S3ObjectInfo(outputS3Path);
-        ListObjectsResponse listing = s3.listObjects(
-                ListObjectsRequest.builder()
+        ListObjectsRequest.Builder listRequestBuilder = ListObjectsRequest.builder()
                         .bucket(s3ObjectInfo.bucket())
                         .prefix(s3ObjectInfo.key())
-                        .maxKeys(1)
-                        .expectedBucketOwner(expectedBucketOwner)
-                        .build()
-        );
+                        .maxKeys(1);
+        if (StringUtils.isNotBlank(expectedBucketOwner)) {
+            listRequestBuilder = listRequestBuilder.expectedBucketOwner(expectedBucketOwner);
+        }
+        ListObjectsResponse listing = s3.listObjects(listRequestBuilder.build());
 
         if (listing.hasContents()) {
             throw new IllegalStateException(String.format("S3 destination contains existing objects: %s. Set 'overwriteExisting' parameter to 'true' to allow overwriting existing objects.", outputS3Path));
@@ -297,12 +297,14 @@ public class NeptuneExportService {
         logger.info("Key   : " + configFileS3ObjectInfo.key());
         logger.info("File  : " + file);
 
-        DownloadFileRequest downloadRequest = DownloadFileRequest.builder()
-                .getObjectRequest(GetObjectRequest.builder()
+        GetObjectRequest.Builder getObjectRequestBuilder = GetObjectRequest.builder()
                         .bucket(configFileS3ObjectInfo.bucket())
-                        .key(configFileS3ObjectInfo.key())
-                        .expectedBucketOwner(expectedBucketOwner)
-                        .build())
+                        .key(configFileS3ObjectInfo.key());
+        if (StringUtils.isNotBlank(expectedBucketOwner)) {
+            getObjectRequestBuilder = getObjectRequestBuilder.expectedBucketOwner(expectedBucketOwner);
+        }
+        DownloadFileRequest downloadRequest = DownloadFileRequest.builder()
+                .getObjectRequest(getObjectRequestBuilder.build())
                 .destination(file.toPath())
                 .build();
 

--- a/src/main/java/com/amazonaws/services/neptune/profiles/neptune_ml/NeptuneMachineLearningExportEventHandlerV1.java
+++ b/src/main/java/com/amazonaws/services/neptune/profiles/neptune_ml/NeptuneMachineLearningExportEventHandlerV1.java
@@ -231,14 +231,16 @@ public class NeptuneMachineLearningExportEventHandlerV1 implements NeptuneExport
         S3ObjectInfo s3ObjectInfo = outputS3ObjectInfo.withNewKeySuffix(filename);
 
         try {
-            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
-                    .source(trainingJobConfigurationFile)
-                    .putObjectRequest(configureServerSideEncryption(PutObjectRequest.builder(), sseKmsKeyId, expectedBucketOwner)
+            PutObjectRequest.Builder putObjectRequestBuilder = configureServerSideEncryption(PutObjectRequest.builder(), sseKmsKeyId, expectedBucketOwner)
                             .bucket(s3ObjectInfo.bucket())
                             .key(s3ObjectInfo.key())
-                            .expectedBucketOwner(expectedBucketOwner)
-                            .tagging(ExportToS3NeptuneExportEventHandler.createObjectTags(profiles))
-                            .build())
+                            .tagging(ExportToS3NeptuneExportEventHandler.createObjectTags(profiles));
+            if (StringUtils.isNotBlank(expectedBucketOwner)) {
+                putObjectRequestBuilder = putObjectRequestBuilder.expectedBucketOwner(expectedBucketOwner);
+            }
+            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
+                    .source(trainingJobConfigurationFile)
+                    .putObjectRequest(putObjectRequestBuilder.build())
                     .build();
 
             FileUpload upload = transferManager.uploadFile(uploadFileRequest);

--- a/src/main/java/com/amazonaws/services/neptune/profiles/neptune_ml/NeptuneMachineLearningExportEventHandlerV2.java
+++ b/src/main/java/com/amazonaws/services/neptune/profiles/neptune_ml/NeptuneMachineLearningExportEventHandlerV2.java
@@ -232,14 +232,16 @@ public class NeptuneMachineLearningExportEventHandlerV2 implements NeptuneExport
         S3ObjectInfo s3ObjectInfo = outputS3ObjectInfo.withNewKeySuffix(filename);
 
         try {
-            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
-                    .source(trainingJobConfigurationFile)
-                    .putObjectRequest(configureServerSideEncryption(PutObjectRequest.builder(), sseKmsKeyId, expectedBucketOwner)
+            PutObjectRequest.Builder putObjectRequestBuilder = configureServerSideEncryption(PutObjectRequest.builder(), sseKmsKeyId, expectedBucketOwner)
                             .bucket(s3ObjectInfo.bucket())
                             .key(s3ObjectInfo.key())
-                            .expectedBucketOwner(expectedBucketOwner)
-                            .tagging(ExportToS3NeptuneExportEventHandler.createObjectTags(profiles))
-                            .build())
+                            .tagging(ExportToS3NeptuneExportEventHandler.createObjectTags(profiles));
+            if (StringUtils.isNotBlank(expectedBucketOwner)) {
+                putObjectRequestBuilder = putObjectRequestBuilder.expectedBucketOwner(expectedBucketOwner);
+            }
+            UploadFileRequest uploadFileRequest = UploadFileRequest.builder()
+                    .source(trainingJobConfigurationFile)
+                    .putObjectRequest(putObjectRequestBuilder.build())
                     .build();
 
             FileUpload upload = transferManager.uploadFile(uploadFileRequest);


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Fixes a bug from https://github.com/aws/neptune-export/pull/196 in which some usages of `expectedBucketOwner` in S3 requests were guarded against empty strings, while others (notably in the ML handlers) remained unguarded.

This PR simply adds blank string guards to the remaining usages of `expectedBucketOwner`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

