### PR TITLE
Bump commons-beanutils to 1.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### New Features and Improvements:
 
+- Bump commons-beanutils to 1.11.0
+
 ### Bug Fixes:
 
 ## Neptune Export v2.1.1 (Release Date: April 8, 2026):

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ### New Features and Improvements:
 
+- Bump gremlin-driver to 3.7.6
 - Bump commons-beanutils to 1.11.0
 
 ### Bug Fixes:

--- a/THIRD-PARTY-LICENSES.txt
+++ b/THIRD-PARTY-LICENSES.txt
@@ -5,7 +5,7 @@
 ** Caffeine; version 2.3.x -- https://github.com/ben-manes/caffeine
 ** rvesse/airline; version 2.9.0 -- https://github.com/rvesse/airline
 ** Google Guava; version 18 -- https://github.com/google/guava
-** Apache Commons Beanutils; version 1.9.x -- http://commons.apache.org/proper/commons-beanutils/
+** Apache Commons Beanutils; version 1.11.0 -- http://commons.apache.org/proper/commons-beanutils/
 ** Apache Commons CLI; version 1.4 -- http://commons.apache.org/proper/commons-cli/
 ** Apache Commons Codec; version 1.15 -- http://commons.apache.org/proper/commons-codec/
 ** Apache Commons Collections; version 3.2.2 -- https://commons.apache.org/proper/commons-collections/
@@ -268,10 +268,10 @@ these copyrights do not in any way effect your rights to use this software
     Copyright (C) 2010 The Guava Authors
 * For Apache Commons Beanutils see also this required NOTICE:
     Apache Commons BeanUtils
-    Copyright 2001-2007 The Apache Software Foundation
+    Copyright 2000-2025 The Apache Software Foundation
 
-    This product includes software developed by
-    The Apache Software Foundation (http://www.apache.org/).
+    This product includes software developed at
+    The Apache Software Foundation (https://www.apache.org/).
 * For Apache Commons CLI see also this required NOTICE:
     Copyright © 2002-2019 The Apache Software Foundation. All Rights Reserved.
 * For Apache Commons Codec see also this required NOTICE:

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
         <skipIntegrationTests>true</skipIntegrationTests>
         <neptuneEndpoint></neptuneEndpoint>
         <aws.sdk.version>2.29.3</aws.sdk.version>
-        <gremlin.version>3.7.3</gremlin.version>
+        <gremlin.version>3.7.6</gremlin.version>
         <slf4j.version>2.0.5</slf4j.version>
         <rdf4j.version>3.5.0</rdf4j.version>
         <amazon.neptune.sigv4.signer.version>3.0.1</amazon.neptune.sigv4.signer.version>
@@ -85,6 +85,22 @@
             <groupId>org.apache.tinkerpop</groupId>
             <artifactId>gremlin-driver</artifactId>
             <version>${gremlin.version}</version>
+            <exclusions>
+                <!-- Exclude vulnerable commons-beanutils 1.9.4 (transitive via gremlin-core).
+                     Can be removed once TinkerPop upgrades to commons-beanutils >= 1.11.0. -->
+                <exclusion>
+                    <groupId>commons-beanutils</groupId>
+                    <artifactId>commons-beanutils</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- Override vulnerable commons-beanutils 1.9.4 from TinkerPop.
+             Can be removed once TinkerPop upgrades to >= 1.11.0. -->
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+            <version>1.11.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Issue #, if available: #210

Description of changes:

Bumps `commons-beanutils` (transitively included via gremlin-driver) to 1.11.0. Our tests show no issues emerging from this bump, although it should be viewed as a short term measure until the dependency can be updated from within TinkerPop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

