### PR TITLE
Fix S3 config file download failure when cleanOutputPath is true

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 
 ### Bug Fixes:
 
+- Fix S3 config file download failure when cleanOutputPath is true
+
 ## Neptune Export v2.1.1 (Release Date: April 8, 2026):
 
 ### New Features and Improvements:

--- a/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
@@ -293,6 +293,11 @@ public class NeptuneExportService {
         S3ObjectInfo configFileS3ObjectInfo = new S3ObjectInfo(s3Path);
         File file = configFileS3ObjectInfo.createDownloadFile(localOutputPath);
 
+        File parentDir = file.getParentFile();
+        if (parentDir != null && !parentDir.exists()) {
+            parentDir.mkdirs();
+        }
+
         logger.info("Bucket: " + configFileS3ObjectInfo.bucket());
         logger.info("Key   : " + configFileS3ObjectInfo.key());
         logger.info("File  : " + file);

--- a/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
+++ b/src/main/java/com/amazonaws/services/neptune/export/NeptuneExportService.java
@@ -295,7 +295,9 @@ public class NeptuneExportService {
 
         File parentDir = file.getParentFile();
         if (parentDir != null && !parentDir.exists()) {
-            parentDir.mkdirs();
+            if (!parentDir.mkdirs()) {
+                throw new RuntimeException("Failed to create directory for download: " + parentDir.getAbsolutePath());
+            }
         }
 
         logger.info("Bucket: " + configFileS3ObjectInfo.bucket());

--- a/src/test/java/com/amazonaws/services/neptune/ExportServiceIntegrationTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/ExportServiceIntegrationTest.java
@@ -24,8 +24,11 @@ import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.*;
 import software.amazon.awssdk.transfer.s3.model.DownloadFileRequest;
 import software.amazon.awssdk.transfer.s3.model.FileDownload;
+import software.amazon.awssdk.transfer.s3.model.FileUpload;
+import software.amazon.awssdk.transfer.s3.model.UploadFileRequest;
 
 import java.io.File;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletionException;
@@ -145,6 +148,78 @@ public class ExportServiceIntegrationTest extends AbstractExportIntegrationTest{
         };
         final NeptuneExportRunner runner = new NeptuneExportRunner(command);
         runner.run();
+    }
+
+    @Test
+    public void testExportPgFromConfigWithS3ConfigFile() {
+        String testName = "testExportPgFromConfigWithS3ConfigFile";
+        String configFileS3Path = s3Path + "/" + testName + "/config.json";
+
+        // Upload the known-good config file to S3
+        uploadFileToS3(
+                "src/test/resources/IntegrationTest/ExportPgFromConfigIntegrationTest/input/config.json",
+                configFileS3Path);
+
+        exit.expectSystemExitWithStatus(0);
+        exit.checkAssertionAfterwards((Assertion) () -> {
+            final File resultDir = new File(outputDir, "output").listFiles()[0];
+            assertEquivalentResults(
+                    new File("src/test/resources/IntegrationTest/ExportPgFromConfigIntegrationTest/testExportPgFromConfig"),
+                    resultDir);
+        });
+        exit.checkAssertionAfterwards(new S3EquivalentResultsAssertion(
+                s3Path,
+                "src/test/resources/IntegrationTest/ExportPgFromConfigIntegrationTest/testExportPgFromConfig",
+                testName + "-export"));
+        exit.checkAssertionAfterwards(new CleanupS3Assertion(s3Path + "/" + testName));
+
+        // Run export-pg-from-config via nesvc with --clean and configFileS3Path.
+        // This exercises the bug path: clearTempFiles() deletes the root path, then
+        // downloadFile() must recreate it before downloading the config file from S3.
+        final String[] command = {
+                "nesvc",
+                "--root-path", outputDir.getPath(),
+                "--clean",
+                "--json", "{" +
+                "    \"command\": \"export-pg-from-config\",\n" +
+                "    \"params\": {\n" +
+                "        \"endpoint\": \"" + neptuneEndpoint + "\",\n" +
+                "        \"useIamAuth\": true\n" +
+                "    },\n" +
+                "    \"outputS3Path\": \"" + s3Path + "/" + testName + "-export\",\n" +
+                "    \"configFileS3Path\": \"" + configFileS3Path + "\"\n" +
+                "}"
+        };
+        final NeptuneExportRunner runner = new NeptuneExportRunner(command);
+        runner.run();
+    }
+
+    private void uploadFileToS3(String localPath, String s3Uri) {
+        S3ObjectInfo s3ObjectInfo = new S3ObjectInfo(s3Uri);
+        try (TransferManagerWrapper transferManager = new TransferManagerWrapper(null)) {
+            UploadFileRequest uploadRequest = UploadFileRequest.builder()
+                    .putObjectRequest(PutObjectRequest.builder()
+                            .bucket(s3ObjectInfo.bucket())
+                            .key(s3ObjectInfo.key())
+                            .build())
+                    .source(Paths.get(localPath))
+                    .build();
+            FileUpload upload = transferManager.get().uploadFile(uploadRequest);
+            upload.completionFuture().join();
+        }
+    }
+
+    private class CleanupS3Assertion implements Assertion {
+        private final String s3Uri;
+
+        public CleanupS3Assertion(String s3Uri) {
+            this.s3Uri = s3Uri;
+        }
+
+        @Override
+        public void checkAssertion() {
+            deleteS3Directory(new S3ObjectInfo(s3Uri));
+        }
     }
 
     private class EquivalentResultsAssertion implements Assertion {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

We've received a bug report where the use of the `configFileS3Path`
export service parameter could cause exports to fail as it attempts to
download the config file into a non-existent directory.

The cause of this failure is as follows:
`clearTempFiles()` deletes the `localOutputPath` directory before
`downloadFile()` attempts to download the config file from S3 into it.
The S3 Transfer Manager does not create parent directories, so the
download fails with `NoSuchFileException`. This cascades into a
poisoned thread interrupt flag (`AbortedException` on the next SDK
call) and a second `NoSuchFileException` when the error handler tries
to upload diagnostics from the non-existent directory.

The fix is simply to ensure the parent directory exists before
downloading by calling `mkdirs()` in `downloadFile()`.

The new integration test is a simple reproduction case of the existing
failure. The test first runs a `create-pg-config` job to upload a config
file to S3, and then it runs `export-pg-from-config` 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

