### PR TITLE
Dependency upgrades and CI hardening

### DIFF
--- a/.github/workflows/maven_build_and_verify.yml
+++ b/.github/workflows/maven_build_and_verify.yml
@@ -23,6 +23,9 @@ on:
         required: false
         default: false
 
+permissions:
+  contents: read
+
 env:
   SIGNING_ENABLED: ${{ github.event.inputs.signJarArtifacts }}
 

--- a/.github/workflows/remove_old_artifacts.yml
+++ b/.github/workflows/remove_old_artifacts.yml
@@ -9,6 +9,8 @@ jobs:
   remove-old-artifacts:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    permissions:
+      actions: write
 
     steps:
       - name: Remove Old Artifacts

--- a/.github/workflows/trufflehog.yml
+++ b/.github/workflows/trufflehog.yml
@@ -15,6 +15,8 @@ on:
 jobs:
   TruffleHog:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 - Bump gremlin-driver to 3.7.6
 - Bump commons-beanutils to 1.11.0
+- Bump plexus-utils to 4.0.3
+- Bump jackson-databind to 2.18.2
 
 ### Bug Fixes:
 

--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,38 @@
         <amazon.neptune.sparql.java.sigv4.version>3.0.1</amazon.neptune.sparql.java.sigv4.version>
         <netty.version>4.2.12.Final</netty.version>
         <kinesis.producer.version>1.0.0</kinesis.producer.version>
-        <jackson.version>2.15.3</jackson.version>
+        <jackson.version>2.18.2</jackson.version>
     </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>1.26.2</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-configuration2</artifactId>
+                <version>2.10.1</version>
+            </dependency>
+            <dependency>
+                <groupId>commons-validator</groupId>
+                <artifactId>commons-validator</artifactId>
+                <version>1.9.0</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.protobuf</groupId>
+                <artifactId>protobuf-java</artifactId>
+                <version>4.30.2</version>
+            </dependency>
+            <dependency>
+                <groupId>com.squareup.okio</groupId>
+                <artifactId>okio-fakefilesystem</artifactId>
+                <version>3.4.0</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <dependencies>
 
@@ -197,7 +227,7 @@
         <dependency>
             <groupId>org.codehaus.plexus</groupId>
             <artifactId>plexus-utils</artifactId>
-            <version>4.0.2</version>
+            <version>4.0.3</version>
         </dependency>
 
         <dependency>
@@ -505,6 +535,11 @@
                         <license implementation="org.apache.rat.analysis.license.ApacheSoftwareLicense20"/>
                     </licenses>
                 </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.owasp</groupId>
+                <artifactId>dependency-check-maven</artifactId>
+                <version>12.1.0</version>
             </plugin>
         </plugins>
         <pluginManagement>

--- a/src/test/java/com/amazonaws/services/neptune/io/StreamTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/io/StreamTest.java
@@ -1,0 +1,92 @@
+/*
+Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.io;
+
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+import org.junit.Before;
+import org.junit.Test;
+import software.amazon.kinesis.producer.KinesisProducer;
+import software.amazon.kinesis.producer.UserRecordResult;
+
+import java.nio.ByteBuffer;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class StreamTest {
+
+    private KinesisProducer kinesisProducer;
+    private Stream stream;
+
+    @Before
+    public void setUp() {
+        kinesisProducer = mock(KinesisProducer.class);
+        when(kinesisProducer.getOutstandingRecordsCount()).thenReturn(0);
+        UserRecordResult result = mock(UserRecordResult.class);
+        when(result.isSuccessful()).thenReturn(true);
+        ListenableFuture<UserRecordResult> future = Futures.immediateFuture(result);
+        when(kinesisProducer.addUserRecord(anyString(), anyString(), any(ByteBuffer.class))).thenReturn(future);
+        stream = new Stream(kinesisProducer, "test-stream", LargeStreamRecordHandlingStrategy.dropAll);
+    }
+
+    @Test
+    public void shouldPublishRecordToKinesis() {
+        stream.publish("{\"key\":\"value\"}");
+
+        verify(kinesisProducer).addUserRecord(eq("test-stream"), anyString(), any(ByteBuffer.class));
+    }
+
+    @Test
+    public void shouldNotPublishEmptyRecord() {
+        stream.publish("");
+
+        verify(kinesisProducer, never()).addUserRecord(anyString(), anyString(), any(ByteBuffer.class));
+    }
+
+    @Test
+    public void shouldNotPublishMinimalJsonArray() {
+        stream.publish("[]");
+
+        verify(kinesisProducer, never()).addUserRecord(anyString(), anyString(), any(ByteBuffer.class));
+    }
+
+    @Test
+    public void shouldFlushRecords() {
+        stream.publish("{\"key\":\"value\"}");
+        stream.flushRecords();
+
+        verify(kinesisProducer).flushSync();
+    }
+
+    @Test
+    public void shouldDropOversizedRecordWithDropAllStrategy() {
+        // Build a record larger than 1MB
+        StringBuilder sb = new StringBuilder();
+        sb.append("{\"key\":\"");
+        for (int i = 0; i < 1_100_000; i++) {
+            sb.append("x");
+        }
+        sb.append("\"}");
+
+        stream.publish(sb.toString());
+
+        // Record exceeds 1MB and strategy is dropAll (no split), so it should be dropped
+        verify(kinesisProducer, never()).addUserRecord(anyString(), anyString(), any(ByteBuffer.class));
+    }
+}


### PR DESCRIPTION
Issue #, if available: N/A

**Description of changes:**

Upgrade `jackson-databind` 2.15.3 -> 2.18.2 (CVE-2023-35116).
Upgrade `plexus-utils` 4.0.2 -> 4.0.3 (CVE-2025-67030).

Pin transitive dependencies via dependencyManagement to resolve CVEs in `amazon-kinesis-producer:1.0.0`:
- `commons-validator` 1.7 -> 1.9.0 (CVE-2025-15104)
- `protobuf-java` 4.29.0 -> 4.30.2 (CVE-2026-0994)
- `okio-fakefilesystem` 3.2.0 -> 3.4.0 (CVE-2023-3635)

Pin existing transitive overrides for `commons-compress` (1.26.2) and `commons-configuration2` (2.10.1).

Add `OWASP` dependency-check-maven plugin.

Add explicit permissions to GitHub Actions workflows to follow least-privilege principle.

**Testing:**
All of these dependency upgrades are relatively low-risk minor upgrades. I consider the existing unit tests as well as the standard suite of integration tests sufficient to validate **most** of these upgrades. The exception being the 3 transitive dependencies of `amazon-kinesis-producer:1.0.0` which were replaced. The kinesis stream path is a bit of a non-standard path and is currently not covered in our standard integration test suite due to the extra AWS resources needed, as well as additional complications in validating correct output. This PR includes a few new stream unit tests, which give some minimal added coverage, but I would still classify as doing a poor job at validating end-to-end kinesis functionality. To cover for this, I have completed some manual testing which includes full exports to kinesis, and properly validating data all data being replicated in the stream.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

