### PR TITLE
Parse gremlin filters with gremlin-lang instead of Groovy engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### New Features and Improvements:
 
+- Parse `--gremlin-filter`, `--gremlin-node-filter`, and `--gremlin-edge-filter` with the gremlin-lang grammar instead of the Groovy script engine.
+- Remove the `gremlin-groovy` dependency, dropping the bundled Groovy libraries from the uber-jar.
+
 ### Bug Fixes:
 
 ## Neptune Export v2.1.2 (Release Date: April 29, 2026):

--- a/pom.xml
+++ b/pom.xml
@@ -134,12 +134,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.tinkerpop</groupId>
-            <artifactId>gremlin-groovy</artifactId>
-            <version>${gremlin.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>sdk-core</artifactId>
             <version>${aws.sdk.version}</version>
@@ -523,6 +517,7 @@
                     <excludes>
                         <exclude>.github/**</exclude>
                         <exclude>**/.idea/**</exclude>
+                        <exclude>**/.kiro/**</exclude>
                         <exclude>**/target/**</exclude>
                         <exclude>*.md</exclude>
                         <exclude>*.json</exclude>

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/GremlinFilters.java
@@ -15,12 +15,12 @@ package com.amazonaws.services.neptune.propertygraph;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.tinkerpop.gremlin.jsr223.CachedGremlinScriptEngineManager;
 import org.apache.tinkerpop.gremlin.jsr223.GremlinScriptEngine;
+import org.apache.tinkerpop.gremlin.process.traversal.AnonymousTraversalSource;
 import org.apache.tinkerpop.gremlin.process.traversal.Bytecode;
 import org.apache.tinkerpop.gremlin.process.traversal.Traversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.structure.Element;
-import org.joda.time.format.DateTimeFormatter;
-import org.joda.time.format.ISODateTimeFormat;
+import org.apache.tinkerpop.gremlin.structure.util.empty.EmptyGraph;
 
 import javax.script.Bindings;
 import javax.script.ScriptException;
@@ -38,34 +38,71 @@ public class GremlinFilters {
 
     private static final List<String> INVALID_OPERATORS = Arrays.asList("addV", "addE", "write", "drop", "sideEffect", "property", "mergeV", "mergeE");
 
+    /*
+     * Filters are supplied by the user as bare anonymous fragments - e.g. has("runways", 2) - but the gremlin-lang
+     * grammar only accepts a complete query rooted at 'g'. We therefore prepend a synthetic root before parsing,
+     * and discard the leading V() instruction in apply() so that the remaining instructions can still be spliced
+     * into a destination traversal at an arbitrary mid-chain position. Do not remove this prefix: without it the
+     * grammar rejects every existing filter with "mismatched input ... expecting {EmptyStringLiteral, 'g'}".
+     */
+    private static final String ROOT_PREFIX = "g.V().";
+
     public GremlinFilters(String gremlinFilter, String gremlinNodeFilter, String gremlinEdgeFilter, boolean filterEdgesEarly) {
         this.filterEdgesEarly = filterEdgesEarly;
 
         CachedGremlinScriptEngineManager scriptEngineManager = new CachedGremlinScriptEngineManager();
-        GremlinScriptEngine engine = scriptEngineManager.getEngineByName("gremlin-groovy");
+        GremlinScriptEngine engine = scriptEngineManager.getEngineByName("gremlin-lang");
         Bindings engineBindings = engine.createBindings();
-        engineBindings.put("datetime", new DatetimeConverter());
 
-        try {
-            this.gremlinFilter = StringUtils.isNotEmpty(gremlinFilter) ?
-                    (Traversal.Admin) engine.eval(gremlinFilter, engineBindings) : null;
-        } catch (ScriptException e) {
-            throw new IllegalStateException(String.format("Invalid Gremlin filter: %s. %s", gremlinFilter, e.getMessage()), e);
+        // gremlin-lang requires a 'g' binding of type TraversalSource, otherwise evaluation fails with an NPE.
+        // The traversal source below is inert: the parsed filters are never executed, cloned or attached to a graph -
+        // they are used purely as bytecode carriers.
+        engineBindings.put("g", AnonymousTraversalSource.traversal().withEmbedded(EmptyGraph.instance()));
+
+        this.gremlinFilter = parseFilter(engine, engineBindings, gremlinFilter, "Gremlin filter");
+        this.gremlinNodeFilter = parseFilter(engine, engineBindings, gremlinNodeFilter, "Gremlin node filter");
+        this.gremlinEdgeFilter = parseFilter(engine, engineBindings, gremlinEdgeFilter, "Gremlin edge filter");
+    }
+
+    private static Traversal.Admin<?, ?> parseFilter(GremlinScriptEngine engine,
+                                                     Bindings bindings,
+                                                     String filter,
+                                                     String description) {
+        if (StringUtils.isEmpty(filter)) {
+            return null;
         }
 
-        try {
-            this.gremlinNodeFilter = StringUtils.isNotEmpty(gremlinNodeFilter) ?
-                    (Traversal.Admin) engine.eval(gremlinNodeFilter, engineBindings) : null;
-        } catch (ScriptException e) {
-            throw new IllegalStateException(String.format("Invalid Gremlin node filter: %s. %s", gremlinNodeFilter, e.getMessage()), e);
+        /*
+         * The gremlin-lang grammar accepts a multi-statement script and returns only the result of the LAST
+         * statement. A filter containing a newline or a semicolon followed by its own g-rooted statement would
+         * therefore silently discard ROOT_PREFIX along with the rest of the user's fragment, yielding something
+         * that is not an anonymous traversal at all (e.g. a bare TraversalSource) and bypassing the operator
+         * denylist in apply(). A filter is only ever a single anonymous traversal fragment, so statement
+         * separators are never legitimate and are rejected up front.
+         */
+        if (StringUtils.containsAny(filter, '\n', '\r', ';')) {
+            throw new IllegalStateException(String.format("Invalid %s: %s. %s", description, filter,
+                    "A Gremlin filter must be a single Gremlin traversal fragment, and must not contain multiple " +
+                            "statements. Remove any newline or semicolon characters."));
         }
 
+        Object result;
+
         try {
-            this.gremlinEdgeFilter = StringUtils.isNotEmpty(gremlinEdgeFilter) ?
-                    (Traversal.Admin) engine.eval(gremlinEdgeFilter, engineBindings) : null;
+            result = engine.eval(ROOT_PREFIX + filter, bindings);
         } catch (ScriptException e) {
-            throw new IllegalStateException(String.format("Invalid Gremlin edge filter: %s. %s", gremlinEdgeFilter, e.getMessage()), e);
+            throw new IllegalStateException(String.format("Invalid %s: %s. %s", description, filter, e.getMessage()), e);
         }
+
+        // Anything other than a traversal cannot be spliced into a destination traversal. Check rather than cast
+        // blindly, so that a raw ClassCastException can never escape in place of the documented message.
+        if (!(result instanceof Traversal.Admin)) {
+            throw new IllegalStateException(String.format("Invalid %s: %s. %s", description, filter,
+                    String.format("A Gremlin filter must be a single Gremlin traversal fragment, but this filter " +
+                            "evaluated to %s.", result == null ? "null" : result.getClass().getName())));
+        }
+
+        return (Traversal.Admin<?, ?>) result;
     }
 
     public GraphTraversal<? extends Element, ?> applyToNodes(GraphTraversal<? extends Element, ?> t) {
@@ -93,8 +130,19 @@ public class GremlinFilters {
     }
 
     private GraphTraversal<? extends Element, ?> apply(GraphTraversal<? extends Element, ?> t, Traversal.Admin<?, ?> gremlin) {
+        boolean isFirst = true;
+
         for (Bytecode.Instruction instruction : gremlin.getBytecode().getInstructions()) {
             String operator = instruction.getOperator();
+
+            if (isFirst) {
+                isFirst = false;
+                // Discard the synthetic root added by ROOT_PREFIX so the fragment can be spliced mid-chain.
+                if (GraphTraversal.Symbols.V.equals(operator) || GraphTraversal.Symbols.E.equals(operator)) {
+                    continue;
+                }
+            }
+
             validateOperator(operator);
             t.asAdmin().getBytecode().addStep(operator, instruction.getArguments());
         }
@@ -105,14 +153,6 @@ public class GremlinFilters {
     private void validateOperator(String operator) {
         if (INVALID_OPERATORS.contains(operator)) {
             throw new IllegalArgumentException(String.format("Invalid operator: '%s'. Gremlin filter cannot contain side effect or mutating step.", operator));
-        }
-    }
-
-    private static class DatetimeConverter {
-        private static final DateTimeFormatter dateTimeFormatter = ISODateTimeFormat.dateTimeParser().withZoneUTC();
-
-        public Object call(String args) {
-            return dateTimeFormatter.parseDateTime(args).toDate();
         }
     }
 }

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/GremlinFiltersTest.java
@@ -16,7 +16,16 @@ import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.GraphTraversal;
 import org.apache.tinkerpop.gremlin.process.traversal.dsl.graph.__;
 import org.junit.Test;
 
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -119,6 +128,231 @@ public class GremlinFiltersTest {
 
         assertEquals("__.inject(\"x\").where(__.or(__.hasLabel(\"person\"),__.has(\"name\",\"Cole\"))).has(\"age\",P.gt((int) 20).and(P.lt((int) 30)))", GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
         assertEquals("__.inject(\"x\").where(__.or(__.hasLabel(\"person\"),__.has(\"name\",\"Cole\"))).has(\"age\",P.gt((int) 20).and(P.lt((int) 30)))", GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    // ---------------------------------------------------------------------------------------------------------------
+    // gremlin-lang parsing layer regression tests
+    // ---------------------------------------------------------------------------------------------------------------
+
+    @Test
+    public void shouldRejectDropStep() {
+        // The gremlin-lang grammar happily parses mutating steps, so the INVALID_OPERATORS denylist is the only thing
+        // that stops them - and it fires at apply time, not at construction time.
+        GremlinFilters filters = new GremlinFilters("drop()", null, null, false);
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToNodes(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'drop'"));
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToEdges(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'drop'"));
+    }
+
+    @Test
+    public void shouldRejectAddVStep() {
+        GremlinFilters filters = new GremlinFilters("addV('x')", null, null, false);
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToNodes(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'addV'"));
+    }
+
+    @Test
+    public void shouldRejectPropertyStep() {
+        GremlinFilters filters = new GremlinFilters("property('k','v')", null, null, false);
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToNodes(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'property'"));
+    }
+
+    @Test
+    public void shouldRejectMutatingStepInNodeFilter() {
+        GremlinFilters filters = new GremlinFilters(null, "drop()", null, false);
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToNodes(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'drop'"));
+    }
+
+    @Test
+    public void shouldRejectMutatingStepInEdgeFilter() {
+        GremlinFilters filters = new GremlinFilters(null, null, "addE('x')", false);
+
+        assertTrue("Exception does not name the rejected operator", assertThrows(IllegalArgumentException.class,
+                () -> filters.applyToEdges(anonymousTraversal())
+        ).getMessage().contains("Invalid operator: 'addE'"));
+    }
+
+    @Test
+    public void shouldStripSyntheticRootFromFilter() {
+        // The filter is parsed as 'g.V().hasLabel("route")' internally; the synthetic V() root must not survive
+        // into the destination traversal, which is spliced at an arbitrary mid-chain position.
+        GremlinFilters filters = new GremlinFilters("hasLabel(\"route\")", null, null, false);
+
+        String nodes = GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal()));
+        String edges = GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal()));
+
+        assertEquals("__.inject(\"x\").hasLabel(\"route\")", nodes);
+        assertEquals("__.inject(\"x\").hasLabel(\"route\")", edges);
+
+        assertFalse("Synthetic V() root leaked into the traversal", nodes.contains(".V("));
+        assertFalse("Synthetic E() root leaked into the traversal", nodes.contains(".E("));
+        assertFalse("Synthetic V() root leaked into the traversal", edges.contains(".V("));
+        assertFalse("Synthetic E() root leaked into the traversal", edges.contains(".E("));
+    }
+
+    @Test
+    public void shouldFailFastOnLambdaSyntaxUnsupportedByNeptune() {
+        // This is an earlier, clearer failure rather than a lost capability. Neptune does not support lambdas in
+        // bytecode requests, so a closure-bearing filter parsed fine at CLI time under the Groovy script engine and
+        // then failed server-side, mid-export. gremlin-lang rejects it up front instead.
+        assertTrue("Exception does not contain expected message", assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters("has('x', 1).map{ it.get() }", null, null, false)
+        ).getMessage().contains("Invalid Gremlin filter: has('x', 1).map{ it.get() }"));
+    }
+
+    @Test
+    public void shouldSpliceMultiStepFragmentsInOrder() {
+        GremlinFilters filters = new GremlinFilters("where(__.has('name','Cole')).hasLabel('person').has('age',31)", null, null, false);
+
+        assertEquals("__.inject(\"x\").where(__.has(\"name\",\"Cole\")).hasLabel(\"person\").has(\"age\",(int) 31)",
+                GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").where(__.has(\"name\",\"Cole\")).hasLabel(\"person\").has(\"age\",(int) 31)",
+                GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    // The multi-statement guard emits this distinctive tail. It is unique to the guard: neither the ScriptException
+    // catch (which appends parser text) nor the instanceof-failure check (which says "...evaluated to <class>.")
+    // produce this sentence, so asserting on it actually pins the guard rather than falling through to another site.
+    private static final String MULTI_STATEMENT_GUARD_TAIL = "Remove any newline or semicolon characters.";
+
+    @Test
+    public void shouldPreserveUserAuthoredLeadingVStep() {
+        // A user filter whose first step is itself named V() parses internally as g.V().V().hasLabel('x'). apply()
+        // strips ONLY the first (synthetic) V instruction, so the user's own V() must survive. This pins that
+        // exactly one root is discarded, not every V/E step in the fragment.
+        GremlinFilters filters = new GremlinFilters("V().hasLabel('x')", null, null, false);
+
+        assertEquals("__.inject(\"x\").V().hasLabel(\"x\")",
+                GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+        assertEquals("__.inject(\"x\").V().hasLabel(\"x\")",
+                GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementFilterWithNewline() {
+        // gremlin-lang evaluates only the LAST statement of a multi-statement script, which would silently discard
+        // the internal synthetic root along with the user's fragment.
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters("has('a',1)\ng", null, null, false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementFilterWithCarriageReturn() {
+        // The guard also checks for '\r'; exercise it explicitly so a future edit that drops '\r' from the guard
+        // is caught. Assert both the prefix and the guard's distinctive tail so it cannot pass by falling through
+        // to another throw site.
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters("has('a',1)\rg", null, null, false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementFilterWithSemicolon() {
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters("has('a',1);g", null, null, false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementFilterSmugglingMutatingStep() {
+        // The multi-statement guard rejects this input up front, at construction time, before apply() and its
+        // operator denylist are ever reached. Asserting the guard's distinctive tail pins that specific throw site.
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters("has('a',1)\ng.addV('x')", null, null, false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementNodeFilter() {
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters(null, "has('a',1)\ng.addV('x')", null, false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin node filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldRejectMultiStatementEdgeFilter() {
+        // The trailing statement here ('g') evaluates to a bare TraversalSource, so without the guard the
+        // instanceof-failure check would also reject it - making a prefix-only assertion tautological. Pin the
+        // guard by additionally asserting its distinctive tail.
+        String message = assertThrows(IllegalStateException.class,
+                () -> new GremlinFilters(null, null, "has('a',1);g", false)
+        ).getMessage();
+        assertTrue("Exception does not contain expected prefix", message.contains("Invalid Gremlin edge filter: "));
+        assertTrue("Exception was not raised by the multi-statement guard", message.contains(MULTI_STATEMENT_GUARD_TAIL));
+    }
+
+    @Test
+    public void shouldBeSafeToShareOneInstanceAcrossThreads() throws Exception {
+        // ExportPropertyGraphJob shares a single GremlinFilters instance across a fixed thread pool, so
+        // applyToNodes/applyToEdges run concurrently against the same parsed traversals. Access must stay read-only.
+        String expected = "__.inject(\"x\").where(__.has(\"name\",\"Cole\")).hasLabel(\"person\")";
+
+        GremlinFilters filters = new GremlinFilters("where(__.has('name','Cole')).hasLabel('person')", null, null, false);
+
+        assertEquals(expected, GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+
+        int threadCount = 8;
+        int iterations = 200;
+
+        AtomicInteger errors = new AtomicInteger();
+        List<String> results = new CopyOnWriteArrayList<>();
+        CountDownLatch startGate = new CountDownLatch(1);
+        ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+
+        try {
+            for (int i = 0; i < threadCount; i++) {
+                executorService.submit(() -> {
+                    try {
+                        startGate.await();
+                        for (int j = 0; j < iterations; j++) {
+                            // Each call targets a distinct destination traversal, as it does during an export.
+                            results.add(GremlinQueryDebugger.queryAsString(filters.applyToNodes(anonymousTraversal())));
+                            results.add(GremlinQueryDebugger.queryAsString(filters.applyToEdges(anonymousTraversal())));
+                        }
+                    } catch (Throwable t) {
+                        errors.incrementAndGet();
+                    }
+                });
+            }
+
+            startGate.countDown();
+            executorService.shutdown();
+            assertTrue("Concurrent filter application did not complete in time",
+                    executorService.awaitTermination(60, TimeUnit.SECONDS));
+        } finally {
+            executorService.shutdownNow();
+        }
+
+        assertEquals("Concurrent filter application threw", 0, errors.get());
+        assertEquals("Unexpected number of results", threadCount * iterations * 2, results.size());
+
+        for (String result : results) {
+            assertEquals(expected, result);
+        }
     }
 
     private GraphTraversal anonymousTraversal() {


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes:

Swaps the script engine used to parse --gremlin-filter, --gremlin-node-filter, and --gremlin-edge-filter from gremlin-groovy to gremlin-lang.

Existing bare-fragment filter syntax is preserved: the user fragment is prefixed with an internal g.V() root before parsing (the gremlin-lang grammar only accepts a g-rooted query) and the synthetic root is stripped before the instructions are spliced into the destination traversal. Output is byte-identical to the previous engine across the full filter corpus, including native datetime() handling, so all existing tests pass unchanged.

Because gremlin-lang evaluates only the last statement of a multi-statement script, parseFilter now rejects filters containing a newline, carriage return, or semicolon up front, and verifies the eval result is a Traversal.Admin before casting, so no raw ClassCastException can escape the documented "Invalid Gremlin filter" error contract. The INVALID_OPERATORS denylist is retained since gremlin-lang still parses mutating steps.

Groovy-only constructs such as closures now fail at parse time rather than server-side mid-export (Neptune does not support lambdas in bytecode requests), and the gremlin-groovy dependency is removed, dropping the bundled Groovy libraries from the uber-jar and removing Groovy evaluation of user-supplied filter strings.

Also adds .kiro to the apache-rat license-check excludes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

