### PR TITLE
Preserve empty-string property values on CSV export

### DIFF
--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsv.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsv.java
@@ -22,6 +22,7 @@ import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -147,7 +148,8 @@ public class RewriteAndMergeCsv implements RewriteCommand {
 
                         CSVFormat format = CSVFormat.RFC4180
                                 .withSkipHeaderRecord(false) // files will not have headers
-                                .withHeader(fileHeaders);
+                                .withHeader(fileHeaders)
+                                .withQuoteMode(QuoteMode.NON_NUMERIC);
 
                         Iterable<CSVRecord> records = format.parse(in);
 
@@ -171,7 +173,7 @@ public class RewriteAndMergeCsv implements RewriteCommand {
                                 }
                             }
 
-                            printer.printProperties(record.toMap(), false);
+                            printer.printProperties(RewriteCsv.propertyValues(record), false);
                             printer.printEndRow();
                         }
 

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsv.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsv.java
@@ -21,6 +21,7 @@ import com.amazonaws.services.neptune.util.CheckedActivity;
 import com.amazonaws.services.neptune.util.Timer;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
 import org.apache.commons.lang3.ArrayUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -148,7 +149,7 @@ public class RewriteCsv implements RewriteCommand {
 
                 renamedFiles.add(target.outputId());
 
-                CSVFormat format = CSVFormat.RFC4180.withHeader(fileHeaders);
+                CSVFormat format = CSVFormat.RFC4180.withHeader(fileHeaders).withQuoteMode(QuoteMode.NON_NUMERIC);
                 Iterable<CSVRecord> records = format.parse(in);
 
                 int recordCount = 0;
@@ -172,7 +173,7 @@ public class RewriteCsv implements RewriteCommand {
                         }
                     }
 
-                    target.printProperties(record.toMap(), false);
+                    target.printProperties(propertyValues(record), false);
                     target.printEndRow();
 
                     recordCount++;
@@ -186,6 +187,26 @@ public class RewriteCsv implements RewriteCommand {
         return new MasterLabelSchema(
                 masterSchema,
                 renamedFiles.stream().map(f -> new FileSpecificLabelSchema(f, targetConfig.format(), masterSchema)).collect(Collectors.toList()));
+    }
+
+    /**
+     * Builds the property map passed to the rewrite printer, preserving the distinction between an
+     * absent property and a property whose value is an empty string.
+     *
+     * <p>The rewrite input is parsed with {@link QuoteMode#NON_NUMERIC}, under which Commons CSV
+     * returns {@code null} for a blank field (an absent property) and {@code ""} for a quoted empty
+     * field (a present, empty-string property). Absent properties are omitted from the returned map
+     * so that {@link CsvPropertyGraphPrinter} emits a blank cell for them, whereas present empty
+     * strings are retained and re-quoted as {@code ""} on output.
+     */
+    static Map<String, String> propertyValues(CSVRecord record) {
+        Map<String, String> values = new LinkedHashMap<>();
+        for (Map.Entry<String, String> entry : record.toMap().entrySet()) {
+            if (entry.getValue() != null) {
+                values.put(entry.getKey(), entry.getValue());
+            }
+        }
+        return values;
     }
 
 }

--- a/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/DataType.java
+++ b/src/main/java/com/amazonaws/services/neptune/propertygraph/schema/DataType.java
@@ -14,7 +14,6 @@ package com.amazonaws.services.neptune.propertygraph.schema;
 
 import com.amazonaws.services.neptune.propertygraph.io.CsvPrinterOptions;
 import com.fasterxml.jackson.core.JsonGenerator;
-import org.apache.commons.lang3.StringUtils;
 
 import java.io.IOException;
 import java.time.Instant;
@@ -249,11 +248,7 @@ public enum DataType {
             if (escapeNewline){
                 escaped = escapeNewlineChar(escaped);
             }
-            if (StringUtils.isNotEmpty(escaped)) {
-                return java.lang.String.format("\"%s\"", escaped);
-            } else {
-                return "";
-            }
+            return java.lang.String.format("\"%s\"", escaped);
         }
 
         private String escapeNewlineChar(String value) {
@@ -263,10 +258,6 @@ public enum DataType {
 
         @Override
         public String formatList(Collection<?> values, CsvPrinterOptions options) {
-            if (values.isEmpty()) {
-                return "";
-            }
-
             return java.lang.String.format("\"%s\"",
                     values.stream().
                             map(v -> DataType.escapeSeparators(v, options.multiValueSeparator())).

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinterTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/CsvPropertyGraphPrinterTest.java
@@ -19,6 +19,7 @@ import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
 import com.amazonaws.services.neptune.propertygraph.schema.PropertySchema;
 import org.apache.commons.csv.CSVFormat;
 import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.csv.QuoteMode;
 import org.junit.Test;
 
 import java.io.IOException;
@@ -174,6 +175,89 @@ public class CsvPropertyGraphPrinterTest {
         testEscapeCharacterAfterPrintPropertiesAndRewrite("A\n\nB",
                 "\"A\\n\\nB\"",
                 new PrinterOptions(CsvPrinterOptions.builder().setEscapeNewline(true).build()));
+    }
+
+    @Test
+    public void shouldWriteQuotedEmptyStringForPresentEmptyStringProperty() throws Exception {
+        StringWriter stringWriter = new StringWriter();
+
+        PropertySchema propertySchema1 = new PropertySchema("property1", false, DataType.String, false, EnumSet.noneOf(DataType.class));
+
+        LabelSchema labelSchema = new LabelSchema(new Label("Entity"));
+        labelSchema.put("property1", propertySchema1);
+
+        HashMap<String, String> props = new HashMap<String, String>() {{
+            put("property1", "");
+        }};
+
+        CsvPropertyGraphPrinter printer = new CsvPropertyGraphPrinter(
+                new PrintOutputWriter("outputId", stringWriter),
+                labelSchema,
+                new PrinterOptions(CsvPrinterOptions.builder().build()));
+
+        printer.printProperties(props);
+
+        assertEquals("\"\"", stringWriter.toString());
+    }
+
+    @Test
+    public void shouldWriteBlankFieldForAbsentPropertyDistinctFromEmptyString() throws Exception {
+        StringWriter stringWriter = new StringWriter();
+
+        LabelSchema labelSchema = new LabelSchema(new Label("person"));
+        labelSchema.put("name", new PropertySchema("name", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("nickname", new PropertySchema("nickname", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+
+        HashMap<String, String> props = new HashMap<String, String>() {{
+            put("name", "Carol"); // nickname absent
+        }};
+
+        CsvPropertyGraphPrinter printer = new CsvPropertyGraphPrinter(
+                new PrintOutputWriter("outputId", stringWriter),
+                labelSchema,
+                new PrinterOptions(CsvPrinterOptions.builder().build()));
+
+        printer.printProperties(props);
+
+        assertEquals("\"Carol\",", stringWriter.toString());
+    }
+
+    @Test
+    public void shouldPreserveEmptyStringThroughRewrite() throws Exception {
+        LabelSchema labelSchema = personSchema();
+        assertEquals("\"Bob\",\"\"", rewriteRow(labelSchema, "\"Bob\",\"\""));
+    }
+
+    @Test
+    public void shouldPreserveAbsentPropertyThroughRewrite() throws Exception {
+        LabelSchema labelSchema = personSchema();
+        assertEquals("\"Carol\",", rewriteRow(labelSchema, "\"Carol\","));
+    }
+
+    private LabelSchema personSchema() {
+        LabelSchema labelSchema = new LabelSchema(new Label("person"));
+        labelSchema.put("name", new PropertySchema("name", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("nickname", new PropertySchema("nickname", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        return labelSchema;
+    }
+
+    // Mirrors the per-record read/reprint performed by RewriteCsv and RewriteAndMergeCsv: parse the
+    // (header-less) CSV row using QuoteMode.NON_NUMERIC so blank vs quoted-empty is distinguishable,
+    // then reprint via the shared RewriteCsv.propertyValues helper with applyFormatting=false.
+    private String rewriteRow(LabelSchema labelSchema, String row) throws Exception {
+        String[] headers = labelSchema.propertySchemas().stream()
+                .map(p -> p.property().toString())
+                .toArray(String[]::new);
+        CSVFormat format = CSVFormat.RFC4180.withHeader(headers).withQuoteMode(QuoteMode.NON_NUMERIC);
+        StringWriter stringWriter = new StringWriter();
+        for (CSVRecord record : format.parse(new StringReader(row))) {
+            CsvPropertyGraphPrinter printer = new CsvPropertyGraphPrinter(
+                    new PrintOutputWriter("outputId", stringWriter),
+                    labelSchema,
+                    new PrinterOptions(CsvPrinterOptions.builder().build()));
+            printer.printProperties(RewriteCsv.propertyValues(record), false);
+        }
+        return stringWriter.toString();
     }
 
     // A set of tests to ensure that String escaping is done properly when CSVPropertyGraphPrinter prints to

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsvTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/RewriteAndMergeCsvTest.java
@@ -1,0 +1,145 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.io.Directories;
+import com.amazonaws.services.neptune.io.DirectoryStructure;
+import com.amazonaws.services.neptune.io.Target;
+import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.schema.DataType;
+import com.amazonaws.services.neptune.propertygraph.schema.FileSpecificLabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.MasterLabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.MasterLabelSchemas;
+import com.amazonaws.services.neptune.propertygraph.schema.PropertySchema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * End-to-end coverage for {@link RewriteAndMergeCsv} (the rewrite-and-consolidate pass that merges
+ * several per-file CSVs for a label into one consolidated file). Drives the real
+ * {@link RewriteAndMergeCsv#execute} against real files on disk and asserts that, across the merge, a
+ * present empty-string property survives as a quoted empty string ({@code ""}) while an absent
+ * property remains a blank field.
+ */
+public class RewriteAndMergeCsvTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void preservesEmptyStringVersusAbsentPropertyAcrossMergedFiles() throws Exception {
+        LabelSchema labelSchema = personSchema();
+
+        // Two header-less source files for the same label, merged into one consolidated file:
+        //   file 1 -> bob: nickname is a present empty string ("")
+        //   file 2 -> carol: nickname is absent (blank field)
+        List<String> output = runRewriteAndMerge(labelSchema, Arrays.asList(
+                Collections.singletonList("\"bob\",\"person\",\"Bob\",\"\""),
+                Collections.singletonList("\"carol\",\"person\",\"Carol\",")));
+
+        assertEquals(Arrays.asList(
+                "\"bob\",\"person\",\"Bob\",\"\"",
+                "\"carol\",\"person\",\"Carol\","), output);
+    }
+
+    private LabelSchema personSchema() {
+        LabelSchema labelSchema = new LabelSchema(new Label("person"));
+        labelSchema.put("name", new PropertySchema("name", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("nickname", new PropertySchema("nickname", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        return labelSchema;
+    }
+
+    // Drives the real RewriteAndMergeCsv.execute against multiple header-less node CSVs on disk and
+    // returns the data lines of the single consolidated output file.
+    private List<String> runRewriteAndMerge(LabelSchema labelSchema, List<List<String>> perFileRows) throws Exception {
+        File root = tmp.newFolder();
+        Directories directories = Directories.createFor(DirectoryStructure.PropertyGraph, root, "export-id", "", "");
+
+        List<FileSpecificLabelSchema> fileSchemas = new ArrayList<>();
+        int index = 0;
+        for (List<String> rows : perFileRows) {
+            File sourceFile = new File(tmp.newFolder(), String.format("nodes-source-%d.csv", index++));
+            try (Writer writer = new FileWriter(sourceFile)) {
+                for (String row : rows) {
+                    writer.write(row);
+                    writer.write("\n");
+                }
+            }
+            fileSchemas.add(new FileSpecificLabelSchema(
+                    sourceFile.getAbsolutePath(), PropertyGraphExportFormat.csv, labelSchema));
+        }
+
+        PropertyGraphTargetConfig targetConfig = new PropertyGraphTargetConfig(
+                directories,
+                null,
+                new PrinterOptions(CsvPrinterOptions.builder().build()),
+                PropertyGraphExportFormat.csv,
+                Target.files,
+                true,
+                false,
+                true);
+
+        MasterLabelSchema masterLabelSchema = new MasterLabelSchema(labelSchema, fileSchemas);
+        Map<Label, MasterLabelSchema> schemas = new HashMap<>();
+        schemas.put(labelSchema.label(), masterLabelSchema);
+        MasterLabelSchemas input = new MasterLabelSchemas(schemas, GraphElementType.nodes);
+
+        RewriteAndMergeCsv command = new RewriteAndMergeCsv(
+                targetConfig, new ConcurrencyConfig(1), new FeatureToggles(Collections.emptyList()));
+
+        MasterLabelSchemas result = command.execute(input);
+
+        List<String> outputIds = result.schemas().stream()
+                .flatMap(s -> s.fileSpecificLabelSchemas().stream())
+                .map(FileSpecificLabelSchema::outputId)
+                .collect(Collectors.toList());
+
+        assertEquals("expected a single consolidated output file", 1, outputIds.size());
+
+        return dataLines(outputIds.get(0));
+    }
+
+    // Returns the data rows of the consolidated file. Data rows always start with a quoted id (");
+    // any header row (written by the writer factory) starts with the token prefix (~) and is excluded.
+    private List<String> dataLines(String path) throws Exception {
+        List<String> lines = new ArrayList<>();
+        for (String line : Files.readAllLines(new File(path).toPath(), StandardCharsets.UTF_8)) {
+            String trimmed = line.replace("\r", "");
+            if (trimmed.startsWith("\"")) {
+                lines.add(trimmed);
+            }
+        }
+        return lines;
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsvTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/io/RewriteCsvTest.java
@@ -1,0 +1,165 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+Licensed under the Apache License, Version 2.0 (the "License").
+You may not use this file except in compliance with the License.
+A copy of the License is located at
+    http://www.apache.org/licenses/LICENSE-2.0
+or in the "license" file accompanying this file. This file is distributed
+on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+express or implied. See the License for the specific language governing
+permissions and limitations under the License.
+*/
+
+package com.amazonaws.services.neptune.propertygraph.io;
+
+import com.amazonaws.services.neptune.cluster.ConcurrencyConfig;
+import com.amazonaws.services.neptune.export.FeatureToggles;
+import com.amazonaws.services.neptune.io.Directories;
+import com.amazonaws.services.neptune.io.DirectoryStructure;
+import com.amazonaws.services.neptune.io.Target;
+import com.amazonaws.services.neptune.propertygraph.Label;
+import com.amazonaws.services.neptune.propertygraph.schema.DataType;
+import com.amazonaws.services.neptune.propertygraph.schema.FileSpecificLabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.GraphElementType;
+import com.amazonaws.services.neptune.propertygraph.schema.LabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.MasterLabelSchema;
+import com.amazonaws.services.neptune.propertygraph.schema.MasterLabelSchemas;
+import com.amazonaws.services.neptune.propertygraph.schema.PropertySchema;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.Writer;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * End-to-end coverage for {@link RewriteCsv} (the second, rewrite pass of a two-pass property-graph
+ * export). Drives the real {@link RewriteCsv#execute} against real files on disk and asserts on the
+ * rewritten output file, verifying that a present empty-string property survives as a quoted empty
+ * string ({@code ""}) while an absent property remains a blank field.
+ */
+public class RewriteCsvTest {
+
+    @Rule
+    public TemporaryFolder tmp = new TemporaryFolder();
+
+    @Test
+    public void preservesEmptyStringVersusAbsentPropertyThroughRewrite() throws Exception {
+        LabelSchema labelSchema = personSchema();
+
+        // Header-less source rows as written by the first export pass:
+        //   bob   -> nickname is a present empty string ("")
+        //   carol -> nickname is absent (blank field)
+        List<String> output = runRewrite(labelSchema, Arrays.asList(
+                "\"bob\",\"person\",\"Bob\",\"\"",
+                "\"carol\",\"person\",\"Carol\","));
+
+        assertEquals(Arrays.asList(
+                "\"bob\",\"person\",\"Bob\",\"\"",
+                "\"carol\",\"person\",\"Carol\","), output);
+    }
+
+    @Test
+    public void preservesMultiValueColumnValuesThroughRewrite() throws Exception {
+        // The rewrite path re-emits each stored value via the scalar String formatter, so a
+        // multi-value column round-trips as its opaque joined string (this does not exercise
+        // DataType.formatList). Covers present-empty, absent, and populated multi-value values.
+        LabelSchema labelSchema = new LabelSchema(new Label("person"));
+        labelSchema.put("name", new PropertySchema("name", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("nickname", new PropertySchema("nickname", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("tags", new PropertySchema("tags", false, DataType.String, true, EnumSet.noneOf(DataType.class)));
+
+        List<String> output = runRewrite(labelSchema, Arrays.asList(
+                // present-empty scalar, populated multi-value list
+                "\"bob\",\"person\",\"Bob\",\"\",\"x;y\"",
+                // absent scalar, absent multi-value list
+                "\"carol\",\"person\",\"Carol\",,",
+                // populated scalar, present-empty multi-value list
+                "\"dave\",\"person\",\"Dave\",\"Dizzy\",\"\""));
+
+        assertEquals(Arrays.asList(
+                "\"bob\",\"person\",\"Bob\",\"\",\"x;y\"",
+                "\"carol\",\"person\",\"Carol\",,",
+                "\"dave\",\"person\",\"Dave\",\"Dizzy\",\"\""), output);
+    }
+
+    private LabelSchema personSchema() {
+        LabelSchema labelSchema = new LabelSchema(new Label("person"));
+        labelSchema.put("name", new PropertySchema("name", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        labelSchema.put("nickname", new PropertySchema("nickname", false, DataType.String, false, EnumSet.noneOf(DataType.class)));
+        return labelSchema;
+    }
+
+    // Drives the real RewriteCsv.execute against a header-less node CSV on disk and returns the data
+    // lines of the rewritten output file.
+    private List<String> runRewrite(LabelSchema labelSchema, List<String> sourceRows) throws Exception {
+        File root = tmp.newFolder();
+        Directories directories = Directories.createFor(DirectoryStructure.PropertyGraph, root, "export-id", "", "");
+
+        File sourceFile = new File(tmp.newFolder(), "nodes-source.csv");
+        try (Writer writer = new FileWriter(sourceFile)) {
+            for (String row : sourceRows) {
+                writer.write(row);
+                writer.write("\n");
+            }
+        }
+
+        PropertyGraphTargetConfig targetConfig = new PropertyGraphTargetConfig(
+                directories,
+                null,
+                new PrinterOptions(CsvPrinterOptions.builder().build()),
+                PropertyGraphExportFormat.csv,
+                Target.files,
+                false,
+                false,
+                true);
+
+        FileSpecificLabelSchema fileSchema =
+                new FileSpecificLabelSchema(sourceFile.getAbsolutePath(), PropertyGraphExportFormat.csv, labelSchema);
+        MasterLabelSchema masterLabelSchema =
+                new MasterLabelSchema(labelSchema, Collections.singletonList(fileSchema));
+        Map<Label, MasterLabelSchema> schemas = new HashMap<>();
+        schemas.put(labelSchema.label(), masterLabelSchema);
+        MasterLabelSchemas input = new MasterLabelSchemas(schemas, GraphElementType.nodes);
+
+        RewriteCsv command = new RewriteCsv(
+                targetConfig, new ConcurrencyConfig(1), new FeatureToggles(Collections.emptyList()));
+
+        MasterLabelSchemas result = command.execute(input);
+
+        List<String> outputIds = result.schemas().stream()
+                .flatMap(s -> s.fileSpecificLabelSchemas().stream())
+                .map(FileSpecificLabelSchema::outputId)
+                .collect(Collectors.toList());
+
+        assertEquals("expected a single rewritten output file", 1, outputIds.size());
+
+        return dataLines(outputIds.get(0));
+    }
+
+    // Returns the data rows of the output file. Data rows always start with a quoted id (");
+    // any header row (written by the writer factory) starts with the token prefix (~) and is excluded.
+    private List<String> dataLines(String path) throws Exception {
+        List<String> lines = new ArrayList<>();
+        for (String line : Files.readAllLines(new File(path).toPath(), StandardCharsets.UTF_8)) {
+            String trimmed = line.replace("\r", "");
+            if (trimmed.startsWith("\"")) {
+                lines.add(trimmed);
+            }
+        }
+        return lines;
+    }
+}

--- a/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/DataTypeTest.java
+++ b/src/test/java/com/amazonaws/services/neptune/propertygraph/schema/DataTypeTest.java
@@ -39,6 +39,24 @@ public class DataTypeTest {
     }
 
     @Test
+    public void emptyStringValueShouldFormatAsQuotedEmptyString() {
+        assertEquals("\"\"", DataType.String.format(""));
+    }
+
+    @Test
+    public void emptyStringValueShouldFormatAsQuotedEmptyStringWhenEscapingNewlines() {
+        assertEquals("\"\"", DataType.String.format("", true));
+    }
+
+    @Test
+    public void emptyListValueShouldFormatAsQuotedEmptyString() {
+        String result = DataType.String.formatList(
+                java.util.Collections.emptyList(),
+                com.amazonaws.services.neptune.propertygraph.io.CsvPrinterOptions.builder().build());
+        assertEquals("\"\"", result);
+    }
+
+    @Test
     public void shouldEscapeTwoDoubleQuotes() {
         String result = DataType.String.format("One \"\"two\"\" three");
         assertEquals("\"One \"\"\"\"two\"\"\"\" three\"", result);


### PR DESCRIPTION
When exporting a property graph to bulk-loader CSV, a property whose value is an empty string was written as a blank cell, identical to a property that was never set. The two cases were indistinguishable, so empty-string values were silently lost on any re-import (including a bulk load back into Neptune).

Per the [Gremlin load data format](https://docs.aws.amazon.com/neptune/latest/userguide/bulk-load-tutorial-format-gremlin.html), a blank field means "no value" while a quoted `""` means "empty string", the exporter wasn't using that distinction.

### Fix

Keep present-empty and absent properties distinct in both directions:

- **Write path (`DataType`):** removed the empty-value special cases in `format` / `formatList` so a present empty string is now emitted as a quoted `""`. Absent properties continue to produce a blank cell (unchanged). This deletes two branches rather than adding any.
- **Rewrite path (`RewriteCsv` / `RewriteAndMergeCsv`):** the second pass re-reads intermediate CSVs with `QuoteMode.NON_NUMERIC`, under which a blank field parses as `null` (absent) and a quoted `""` as an empty string. A shared `propertyValues` helper drops the nulls so absent properties stay blank while empty strings are re-quoted as `""`.

### Example

For a `person` with an empty-string `nickname`:

| case | before | after |
|---|---|---|
| present empty string | `bob,person,"Bob",` | `bob,person,"Bob",""` |
| absent property | `carol,person,"Carol",` | `carol,person,"Carol",` |

### Testing

- Unit tests for `DataType.format` / `formatList` (empty string, empty string with
    newline-escaping, empty list).
- Printer-level tests for present-empty → `""` and absent → blank.
- End-to-end tests driving the real `RewriteCsv` and `RewriteAndMergeCsv` (including a
    merge across files and a multi-value column) against files on disk.
